### PR TITLE
fix(devcontainer): update extensions, remove obsolete black formatter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,9 +44,11 @@
 			"extensions": [
 				"ms-python.python",
 				"ms-python.vscode-pylance",
-				"ms-python.black-formatter",
 				"charliermarsh.ruff",
 				"tamasfe.even-better-toml",
+				"redhat.vscode-yaml",
+				"yzhang.markdown-all-in-one",
+				"usernamehw.errorlens",
 				"GitHub.copilot",
 				"GitHub.copilot-chat",
 				"donjayamanne.githistory",
@@ -54,7 +56,8 @@
 				"ms-azuretools.vscode-docker",
 				"Anthropic.claude-code",
 				"mtxr.sqltools",
-				"mtxr.sqltools-driver-pg"
+				"mtxr.sqltools-driver-pg",
+				"mtxr.sqltools-driver-mssql"
 			],
 			"settings": {
 				"python.defaultInterpreterPath": "/usr/local/bin/python",


### PR DESCRIPTION
## Summary

- Remove `ms-python.black-formatter` (project uses ruff for formatting, not black)
- Add `mtxr.sqltools-driver-mssql` — SQL Server connectivity from VS Code
- Add `redhat.vscode-yaml` — YAML editing for openspec config and docker-compose
- Add `yzhang.markdown-all-in-one` — markdown preview for docs and specs
- Add `usernamehw.errorlens` — inline error display

Also verified: SQL Server env var naming (`SQLSERVER_PASSWORD`) in `post-create.sh` is correct — docker-compose maps `MSSQL_SA_PASSWORD` → `SQLSERVER_PASSWORD` for the backend service.

## Test plan

- [ ] "Reopen in Container" works in VS Code
- [ ] All extensions install correctly
- [ ] `pytest tests/ -v` runs inside devcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)