### PR TITLE
fix(cors): replace wildcard origins with configurable CORS_ORIGINS

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -6,6 +6,7 @@
 ENVIRONMENT=local
 DEBUG=true
 LOG_LEVEL=INFO
+CORS_ORIGINS=http://localhost:5173,http://localhost:8000
 
 # PostgreSQL (Docker service)
 POSTGRES_DB=rag_challenge

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ ENVIRONMENT=local
 # Application Settings
 DEBUG=false
 LOG_LEVEL=INFO
+CORS_ORIGINS=http://localhost:5173,http://localhost:8000
 
 # GitHub Repository (StatsBomb Open Data)
 BASE_URL=https://github.com/statsbomb/open-data/raw/master/data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+- Replace `allow_origins=["*"]` with configurable `CORS_ORIGINS` env var in CORS middleware
+- Add `cors_origins` setting to `config/settings.py` with safe localhost defaults
+
 ### Added
 - `AGENTS.md` — single source of truth for all project conventions and agent rules
 - `CLAUDE.md` — Claude Code entry point with project overview, commands, and governance chain

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,7 +37,7 @@ app = FastAPI(
 # Configure CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # TODO: Configure for production
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/tests/api/test_cors_middleware.py
+++ b/backend/tests/api/test_cors_middleware.py
@@ -1,0 +1,54 @@
+"""API tests for CORS middleware behavior."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+
+def _make_app(origins: list[str]) -> FastAPI:
+    """Create a minimal FastAPI app with CORS middleware for testing."""
+    app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.get("/api/v1/health")
+    def health():
+        return {"status": "ok"}
+
+    return app
+
+
+class TestCorsMiddleware:
+    def test_cors_allows_configured_origin(self):
+        """3.4 — Verify Access-Control-Allow-Origin present for allowed origin."""
+        app = _make_app(["http://localhost:5173", "http://localhost:8000"])
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.options(
+            "/api/v1/health",
+            headers={
+                "Origin": "http://localhost:5173",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.headers.get("access-control-allow-origin") == "http://localhost:5173"
+
+    def test_cors_rejects_unknown_origin(self):
+        """3.5 — Verify header absent for unknown origin."""
+        app = _make_app(["http://localhost:5173", "http://localhost:8000"])
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.options(
+            "/api/v1/health",
+            headers={
+                "Origin": "https://evil.example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert "access-control-allow-origin" not in response.headers

--- a/backend/tests/unit/test_cors_config.py
+++ b/backend/tests/unit/test_cors_config.py
@@ -1,0 +1,37 @@
+"""Unit tests for CORS origins configuration in Settings."""
+
+import pytest
+
+from app.core.config import Settings
+
+
+class TestCorsOriginsConfig:
+    def test_cors_origins_parsed_from_env(self, monkeypatch):
+        """3.1 — Verify comma-separated CORS_ORIGINS is split into a list."""
+        monkeypatch.setenv("CORS_ORIGINS", "https://app.example.com,https://admin.example.com")
+
+        s = Settings()
+        assert s.cors_origins == [
+            "https://app.example.com",
+            "https://admin.example.com",
+        ]
+
+    def test_cors_origins_default_when_unset(self, monkeypatch):
+        """3.2 — Verify default localhost origins when CORS_ORIGINS is not set."""
+        monkeypatch.delenv("CORS_ORIGINS", raising=False)
+
+        s = Settings()
+        assert "http://localhost:5173" in s.cors_origins
+        assert "http://localhost:8000" in s.cors_origins
+
+    def test_cors_origins_strips_whitespace(self, monkeypatch):
+        """3.3 — Verify whitespace is trimmed from each origin."""
+        monkeypatch.setenv(
+            "CORS_ORIGINS", "http://localhost:5173 , http://localhost:8000 "
+        )
+
+        s = Settings()
+        assert s.cors_origins == [
+            "http://localhost:5173",
+            "http://localhost:8000",
+        ]

--- a/config/settings.py
+++ b/config/settings.py
@@ -5,8 +5,7 @@ This module provides type-safe, validated configuration management for the RAG C
 All environment variables are read once at startup and validated, following fail-fast principle.
 """
 
-import os
-from typing import Literal, Optional
+from typing import List, Literal
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -76,6 +75,17 @@ class Settings(BaseSettings):
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     openai: OpenAIConfig = Field(default_factory=OpenAIConfig)
     repository: RepositoryConfig = Field(default_factory=RepositoryConfig)
+
+    # CORS
+    cors_origins_str: str = Field(
+        default="http://localhost:5173,http://localhost:8000",
+        alias="CORS_ORIGINS",
+    )
+
+    @property
+    def cors_origins(self) -> List[str]:
+        """Return CORS origins as a list, splitting on commas."""
+        return [origin.strip() for origin in self.cors_origins_str.split(",")]
 
     # Application settings
     debug: bool = Field(default=False)

--- a/docs/conversation_log.md
+++ b/docs/conversation_log.md
@@ -11,6 +11,32 @@ Cada sesión significativa con un agente AI se documenta aquí para auditoría y
 
 ---
 
+## Fase OpenSpec changes (Sessions 18+, branch: develop)
+
+---
+
+### [2026-04-06] Session 18 — CORS hardening (fix/016-cors-hardening)
+
+**Participants:** Eladio Rincon + Claude Code (Claude Opus 4.6)
+**Branch:** fix/016-cors-hardening
+
+#### Decisions taken
+- Replace `allow_origins=["*"]` with configurable `CORS_ORIGINS` env var
+- Store as `cors_origins_str` (string field) with a `cors_origins` property that splits on commas — avoids pydantic-settings JSON parse issue with `List[str]`
+- API test for CORS middleware uses a dedicated mini FastAPI app instead of patching the real app (middleware is configured at import time)
+- Cleaned up unused imports (`os`, `Optional`) in `config/settings.py`
+
+#### Files modified
+- `config/settings.py` — added `cors_origins_str` field + `cors_origins` property
+- `backend/app/main.py` — replaced `allow_origins=["*"]` with `settings.cors_origins`
+- `.env.example`, `.env.docker.example` — added `CORS_ORIGINS`
+- `backend/tests/unit/test_cors_config.py` — 3 unit tests for Settings parsing
+- `backend/tests/api/test_cors_middleware.py` — 2 API tests for middleware allow/reject
+- `openspec/changes/cors-hardening/` — full OpenSpec change (proposal, design, specs, tasks)
+- `CHANGELOG.md` — added Security entry
+
+---
+
 ## Fase spec-kit (Sessions 1-12, branch: develop)
 
 ---

--- a/openspec/changes/cors-hardening/.openspec.yaml
+++ b/openspec/changes/cors-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-06

--- a/openspec/changes/cors-hardening/design.md
+++ b/openspec/changes/cors-hardening/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The FastAPI backend currently configures CORS with `allow_origins=["*"]` in `backend/app/main.py:40`.
+This allows any domain to make cross-origin requests, which is a security risk for production.
+The project uses Pydantic Settings (`config/settings.py`) for all configuration, but CORS
+origins are not yet managed there.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make CORS origins configurable via environment variable (`CORS_ORIGINS`)
+- Provide safe defaults for local development (`localhost:5173`, `localhost:8000`)
+- Follow existing config pattern: Pydantic Settings → `.env` → `get_settings()`
+
+**Non-Goals:**
+- Per-route CORS configuration
+- Dynamic CORS (runtime changes without restart)
+- CORS preflight caching tuning
+
+## Decisions
+
+### 1. Config location: `config/settings.py` → `Settings` class
+
+**Rationale:** All configuration lives in `config/settings.py` per project convention.
+Adding a `cors_origins` field to the top-level `Settings` class keeps it consistent.
+
+**Alternative considered:** Separate `CorsConfig` nested model — rejected because
+this is a single field, not a config group.
+
+### 2. Env var format: comma-separated string
+
+```
+CORS_ORIGINS=http://localhost:5173,http://localhost:8000
+```
+
+**Rationale:** Simple, no JSON parsing needed. Pydantic `field_validator` splits on commas.
+Consistent with how other FastAPI projects handle this.
+
+**Alternative considered:** JSON array (`["http://..."]`) — rejected, harder to set in
+Docker Compose and `.env` files.
+
+### 3. Default value: local dev origins
+
+Default: `http://localhost:5173,http://localhost:8000`
+
+**Rationale:** Matches current Docker Compose setup. Production MUST override via env var.
+The `*` wildcard is never a default.
+
+## File changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `config/settings.py` | (modified) | Add `cors_origins` field with validator |
+| `backend/app/main.py` | (modified) | Read CORS origins from `get_settings()` |
+| `.env.example` | (modified) | Add `CORS_ORIGINS` variable |
+| `.env.docker.example` | (modified) | Add `CORS_ORIGINS` variable |
+| `backend/tests/unit/test_cors_config.py` | (new) | Unit test for CORS origins parsing |
+| `backend/tests/api/test_cors_middleware.py` | (new) | API test for CORS headers |
+
+## Risks / Trade-offs
+
+- **[Risk]** Existing deployments without `CORS_ORIGINS` set → **Mitigation:** defaults to localhost origins, which is safe (rejects external requests)
+- **[Risk]** Developers forget to set `CORS_ORIGINS` for non-localhost frontend → **Mitigation:** clear error in docs and `.env.example`
+
+## Rollback strategy
+
+Revert the commit. The only change is config-driven — no data migration, no schema changes.

--- a/openspec/changes/cors-hardening/proposal.md
+++ b/openspec/changes/cors-hardening/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The backend uses `allow_origins=["*"]` in CORS middleware (`app/main.py:40`), which allows
+any domain to make cross-origin requests. This is a security risk flagged in `AGENTS.md`
+(Security rules: "No `allow_origins=["*"]` in production"). The TODO comment in the code
+confirms this was always intended as temporary. Fixing it now because governance is in place
+and the project is approaching production readiness.
+
+## What Changes
+
+- Replace hardcoded `allow_origins=["*"]` with a configurable list from `CORS_ORIGINS` env var
+- Add `CORS_ORIGINS` to `config/settings.py` (Pydantic Settings) with sensible defaults for local dev
+- Update `.env.example` and `.env.docker.example` with the new variable
+- Backwards-compatible: defaults to `http://localhost:5173,http://localhost:8000` (current dev setup)
+
+## Capabilities
+
+### New Capabilities
+
+(none — this is a security hardening of existing behavior)
+
+### Modified Capabilities
+
+- `infra`: CORS configuration moves from hardcoded to environment-driven via Pydantic Settings
+
+## Impact
+
+- **Affected layers:** Core (config), API (main.py middleware setup)
+- **Affected files:** `config/settings.py`, `backend/app/main.py`, `.env.example`, `.env.docker.example`
+- **Test impact:** Unit test for CORS origins parsing; API test to verify middleware rejects unknown origins
+- **Backwards compatibility:** Fully compatible — defaults match current dev behavior
+- **Breaking:** None. Production deployments must set `CORS_ORIGINS` env var

--- a/openspec/changes/cors-hardening/specs/infra/spec.md
+++ b/openspec/changes/cors-hardening/specs/infra/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: CORS configuration
+
+The system SHALL read allowed CORS origins from the `CORS_ORIGINS` environment variable.
+The value MUST be a comma-separated list of origin URLs (e.g., `http://localhost:5173,http://localhost:8000`).
+When `CORS_ORIGINS` is not set, the system SHALL default to `http://localhost:5173,http://localhost:8000`.
+The system MUST NOT use `allow_origins=["*"]` in any environment.
+
+#### Scenario: CORS origins loaded from environment variable
+- **WHEN** `CORS_ORIGINS` is set to `https://app.example.com,https://admin.example.com`
+- **THEN** the CORS middleware SHALL accept requests from `https://app.example.com` and `https://admin.example.com`
+- **AND** reject requests from any other origin
+
+#### Scenario: CORS origins default when env var is absent
+- **WHEN** `CORS_ORIGINS` is not set in the environment
+- **THEN** the CORS middleware SHALL accept requests from `http://localhost:5173` and `http://localhost:8000`
+- **AND** reject requests from any other origin
+
+#### Scenario: CORS origins parsing handles whitespace
+- **WHEN** `CORS_ORIGINS` is set to `http://localhost:5173 , http://localhost:8000`
+- **THEN** the system SHALL trim whitespace and accept both origins
+
+#### Scenario: CORS rejects wildcard origin
+- **WHEN** a request arrives from an origin not in the configured list
+- **THEN** the response SHALL NOT include the `Access-Control-Allow-Origin` header

--- a/openspec/changes/cors-hardening/tasks.md
+++ b/openspec/changes/cors-hardening/tasks.md
@@ -1,0 +1,17 @@
+## 1. Configuration
+
+- [x] 1.1 Add `cors_origins` field to `Settings` class in `config/settings.py` with `CORS_ORIGINS` env alias and comma-split validator
+- [x] 1.2 Add `CORS_ORIGINS` to `.env.example` with default `http://localhost:5173,http://localhost:8000`
+- [x] 1.3 Add `CORS_ORIGINS` to `.env.docker.example` with same default
+
+## 2. API layer
+
+- [x] 2.1 Update `backend/app/main.py` CORS middleware to read origins from `get_settings().cors_origins`
+
+## 3. Tests (TDD — write before implementation)
+
+- [x] 3.1 Write unit test: `test_cors_origins_parsed_from_env` — verify comma-separated string is split into list
+- [x] 3.2 Write unit test: `test_cors_origins_default_when_unset` — verify default localhost origins
+- [x] 3.3 Write unit test: `test_cors_origins_strips_whitespace` — verify whitespace trimming
+- [x] 3.4 Write API test: `test_cors_allows_configured_origin` — verify `Access-Control-Allow-Origin` present for allowed origin
+- [x] 3.5 Write API test: `test_cors_rejects_unknown_origin` — verify header absent for unknown origin


### PR DESCRIPTION
## Summary
- Replace hardcoded `allow_origins=["*"]` with configurable `CORS_ORIGINS` env var (comma-separated)
- Add `cors_origins` setting to `config/settings.py` with safe localhost defaults (`http://localhost:5173,http://localhost:8000`)
- Add 5 tests (3 unit for Settings parsing + 2 API for middleware allow/reject)

## Security
Closes the `allow_origins=["*"]` risk flagged in `AGENTS.md`. Production deployments must set `CORS_ORIGINS` explicitly.

## Files changed
| File | Change |
|------|--------|
| `config/settings.py` | Add `cors_origins_str` field + `cors_origins` property |
| `backend/app/main.py` | Use `settings.cors_origins` instead of `["*"]` |
| `.env.example`, `.env.docker.example` | Add `CORS_ORIGINS` variable |
| `backend/tests/unit/test_cors_config.py` | 3 unit tests (parsing, defaults, whitespace) |
| `backend/tests/api/test_cors_middleware.py` | 2 API tests (allow configured, reject unknown) |
| `openspec/changes/cors-hardening/` | OpenSpec change artifacts |
| `CHANGELOG.md` | Security entry under `[Unreleased]` |
| `docs/conversation_log.md` | Session 18 |

## Test plan
- [x] 439 tests pass (`pytest tests/ -v`)
- [x] Coverage ≥ 80% (80.52%)
- [x] Lint clean (`ruff check`)
- [x] CHANGELOG updated
- [x] Conversation log updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)