### PR TITLE
chore(docs): add OpenSpec verification rules and TDD lessons

### DIFF
--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -147,6 +147,11 @@ What would you like to do?
 - Update task checkbox immediately after completing each task
 - Pause on errors, blockers, or unclear requirements - don't guess
 - Use contextFiles from CLI output, don't assume specific file names
+- **Never mark a task `[x]` without running its tests first** — a checkbox means "done and verified", not "code written"
+- **Run `pytest` on each test file immediately after creating it** — catch import errors and assertion failures early
+- **Verify imports from the test runner's cwd** (`backend/`), not from the repo root — e.g., use `app.core.config` not `config.settings`
+- **Module-level side effects (middleware, singletons) cannot be patched after import** — if testing middleware, build a dedicated test app
+- **Run the full suite** (`pytest tests/`) before considering the change complete — a single file passing is not enough
 
 **Fluid Workflow Integration**
 

--- a/.github/instructions/tdd.instructions.md
+++ b/.github/instructions/tdd.instructions.md
@@ -115,6 +115,22 @@ Las factories están definidas en `backend/tests/conftest.py`:
 - Siempre usar los mismos parámetros bind que la aplicación (`%s` para PostgreSQL, `?` para SQL Server).
 - Los tests de integración con BD real deben limpiar sus datos en teardown.
 
+## OpenSpec + TDD integration
+
+When implementing an OpenSpec change (`/opsx:apply`):
+
+1. **Write each test file first** (Red phase), then run it to confirm it fails for the right reason.
+2. **Implement the minimum code** to make the test pass (Green phase).
+3. **Run `pytest` on the file before marking the task `[x]`** — a checkbox means "done and verified".
+4. **After all tasks are done**, run the full suite: `pytest tests/ -v`.
+
+### Common pitfalls
+
+- **Import paths:** Tests run from `backend/` — use `app.core.config` (not `config.settings`).
+- **pydantic-settings `List[str]`:** Env vars are parsed as JSON before validators run. Use `str` field + `@property` to split.
+- **Middleware testing:** CORS and other middleware is configured at module import time. Patching `get_settings()` after import has no effect. Build a dedicated mini-app in the test instead.
+- **Singletons:** `settings = Settings()` at module level means patches to the class don't affect the existing instance. Either patch the instance attribute or create a new instance in the test.
+
 ## CI Integration
 
 El pipeline de CI (`.github/workflows/ci.yml`) ejecuta:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,18 @@ When a developer asks to implement a feature:
 3. If spec exists: proceed with `/opsx:apply`.
 4. After implementation: suggest `/opsx:archive`.
 
+### Verification rules (mandatory)
+
+- **Never mark a task `[x]` until the code compiles and tests pass.**
+  Run `pytest` on every test file you create or modify before checking off.
+- **Verify imports from the test runner's working directory** (`backend/`),
+  not from the repo root. Use `app.core.config` (not `config.settings`).
+- **Run the full test suite** (`pytest tests/ -v`) before considering a change complete.
+- **If pydantic-settings is involved:** `List[str]` fields fail with env vars because
+  pydantic-settings attempts JSON parse before validators. Use `str` + `@property` instead.
+- **Middleware and module-level config cannot be patched after import.**
+  If testing middleware behavior, build a dedicated test app instead of patching.
+
 Available commands (core profile):
 - `/opsx:propose` — create change with proposal, design, specs, tasks
 - `/opsx:apply` — implement tasks from a change

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -29,3 +29,10 @@ rules:
     - Group by layer (API, Service, Repository, Test)
     - Each task should be completable in less than 1 hour
     - Include a test task for each implementation task
+    - Never mark a task [x] until tests pass — run pytest before checking off
+    - Test tasks must verify imports resolve from the test runner cwd (backend/)
+  apply:
+    - Run pytest on each test file immediately after writing it
+    - Run the full test suite before considering the change complete
+    - If a test fails, fix it before moving to the next task
+    - Verify module-level side effects (middleware, singletons) cannot be patched after import


### PR DESCRIPTION
## Summary
- Add mandatory verification rules to the OpenSpec workflow based on lessons from cors-hardening (#14)
- Tasks were marked `[x]` without running tests, imports were wrong, middleware patching didn't work

## Files changed
| File | Change |
|------|--------|
| `AGENTS.md` | 5 verification rules in OpenSpec workflow section |
| `openspec/config.yaml` | New `apply:` rules section + task verification rules |
| `.claude/skills/openspec-apply-change/SKILL.md` | 5 guardrails for test verification |
| `.github/instructions/tdd.instructions.md` | New "OpenSpec + TDD integration" section with common pitfalls |

## Key rules added
- Never mark a task `[x]` without running tests first
- Verify imports from `backend/` cwd (use `app.core.config` not `config.settings`)
- pydantic-settings `List[str]` → use `str` + `@property` instead
- Middleware testing → build dedicated test app, don't patch after import
- Run full suite before considering a change complete

## Test plan
- [x] Documentation-only change — no code modified
- [x] Verified existing tests still pass (439 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)