### PR TITLE
chore(docs): add worktree parallel workflow for OpenSpec changes

### DIFF
--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -153,6 +153,18 @@ What would you like to do?
 - **Module-level side effects (middleware, singletons) cannot be patched after import** — if testing middleware, build a dedicated test app
 - **Run the full suite** (`pytest tests/`) before considering the change complete — a single file passing is not enough
 
+**Parallel Apply with Worktrees**
+
+Multiple OpenSpec changes can be applied in parallel using worktree isolation:
+
+- **When to parallelize**: User explicitly requests it, and changes touch different files/layers
+- **How**: Launch one agent per change with `isolation: "worktree"`. Each agent gets its own branch and working directory
+- **Each agent**: creates branch (`fix/NNN-*` or `feature/NNN-*`) → applies tasks → runs full test suite → commits
+- **Output**: Each worktree produces one PR against `develop`
+- **Limits**: 2–3 parallel worktrees max. Dependencies must be installed per worktree if new packages are added
+- **Merge order**: PRs are merged sequentially into `develop`; later PRs rebase if conflicts arise
+- **Cleanup**: Worktrees with no changes are automatically removed; others are cleaned after PR merge
+
 **Fluid Workflow Integration**
 
 This skill supports the "actions on a change" model:

--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -105,6 +105,40 @@ chore(ci): update ruff to 0.15.8
 4. Merge con "Squash and merge" si hay muchos commits intermedios.
 5. Borrar rama tras merge.
 
+## Worktrees para desarrollo paralelo
+
+### Cuándo usar worktrees
+
+Usar git worktrees cuando se implementan múltiples OpenSpec changes en paralelo.
+Cada worktree es un directorio aislado con su propia rama, vinculado al mismo repositorio.
+
+### Reglas
+
+1. **Proponer primero** — todos los `/opsx:propose` se ejecutan en `develop` antes de paralelizar.
+2. **Una rama por worktree** — cada worktree usa su propia rama (`feature/NNN-*`, `fix/NNN-*`).
+   Una rama checked out en un worktree no puede usarse en otro.
+3. **Independencia de cambios** — solo paralelizar changes que no toquen los mismos ficheros.
+4. **Dependencias por worktree** — si se añaden paquetes, ejecutar `pip install` en cada worktree.
+5. **Limpieza obligatoria** — worktrees sin cambios se eliminan automáticamente;
+   los que tienen cambios se limpian tras merge del PR con `git worktree remove <path>`.
+6. **Límite práctico** — máximo 2–3 worktrees paralelos para minimizar riesgo de conflictos.
+7. **Merge secuencial** — mergear PRs uno a uno en `develop`; rebase si hay conflictos.
+8. **No ejecutar `git gc`** mientras haya worktrees activos (comparten `.git`).
+
+### Ejemplo de flujo
+
+```bash
+# 1. Proponer cambios en develop
+/opsx:propose fix-data-explorer
+/opsx:propose fix-dependency-injection
+
+# 2. Lanzar agentes paralelos con isolation: worktree
+# Cada agente: crea rama → aplica tasks → pytest → commit
+
+# 3. Cada agente genera un PR contra develop
+# 4. Merge secuencial → archive cada change
+```
+
 ## Tags y releases
 
 - Al mergear `develop` → `main`, crear tag: `vX.Y.Z`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,35 @@ Available commands (core profile):
 - `/opsx:archive` — archive completed change
 - `/opsx:explore` — thinking partner mode (read-only, no code changes)
 
+### Parallel development with worktrees
+
+Multiple OpenSpec changes can be implemented in parallel using git worktrees.
+Each change runs in an isolated worktree with its own branch, preventing file conflicts.
+
+**When to use parallel worktrees:**
+- Two or more OpenSpec changes are independent (different files/layers).
+- The user explicitly asks for parallel execution.
+- Changes are already proposed (`openspec/changes/<name>/tasks.md` exists).
+
+**When NOT to use:**
+- Changes touch the same files (e.g., both modify `main.py` or `settings.py`).
+- One change depends on another's output.
+- Only one change is in progress.
+
+**Workflow:**
+1. **Propose first** — run `/opsx:propose` for each change on `develop` (sequential).
+2. **Apply in parallel** — launch one agent per change with `isolation: "worktree"`.
+   Each agent creates its own branch (`fix/NNN-*` or `feature/NNN-*`).
+3. **Verify each** — each agent runs `pytest tests/ -v` in its worktree before finishing.
+4. **PR per change** — each worktree produces one PR against `develop`.
+5. **Merge in order** — merge PRs sequentially; if conflicts arise, rebase the later PR.
+6. **Archive** — run `/opsx:archive` for each merged change.
+
+**Practical limits:**
+- 2–3 parallel worktrees recommended; more increases merge conflict risk.
+- Each worktree needs its own dependency install if adding packages.
+- Worktrees with no changes are automatically cleaned up.
+
 ## Restrictions
 
 - **DO NOT** delete files without explicit user confirmation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ This project uses [OpenSpec](https://github.com/Fission-AI/OpenSpec) for spec-dr
 - Implement with `/opsx:apply`, archive with `/opsx:archive`.
 - System specs live in `openspec/specs/` (api, rag, data, infra).
 - Active changes live in `openspec/changes/`, archived in `openspec/changes/archive/`.
+- **Parallel apply**: independent changes can be applied in parallel using `isolation: "worktree"`.
+  See `AGENTS.md` § "Parallel development with worktrees" for rules and limits.
 
 ## Claude-specific tools
 

--- a/docs/PLAN_OPENSPEC_ADOPTION.md
+++ b/docs/PLAN_OPENSPEC_ADOPTION.md
@@ -393,22 +393,61 @@ git push origin feature/openspec-governance
 
 **Lección aprendida:** En un brownfield, las specs iniciales sirven como "fotografía" del sistema, no como verdad aspiracional. Las desviaciones se documentan explícitamente para que futuros `/opsx:propose` las puedan corregir.
 
-### Paso 6 — Primer cambio real con OpenSpec (pendiente)
+### Paso 6 — Primer cambio real con OpenSpec (2026-04-06)
 
-*Se ejecutará con `/opsx:propose fix-dependency-injection` para validar el workflow completo.*
+**Problema:** Validar el workflow completo de OpenSpec end-to-end con un cambio real.
 
-### Paso 5 — Documentar specs del sistema actual (pendiente)
+**Cambio elegido:** `cors-hardening` — reemplazar `allow_origins=["*"]` por `CORS_ORIGINS` configurable (deuda técnica identificada en sección 2.2).
 
-*Se completará con `/opsx:explore` y creación manual de specs iniciales.*
+**Acciones realizadas:**
+1. `/opsx:propose cors-hardening` → generó proposal, design, specs/infra, tasks
+2. `/opsx:apply` → implementación TDD (5 tests + código)
+3. PR #14 mergeado a `develop`
 
-### Paso 6 — Primer cambio real con OpenSpec (pendiente)
+**Lecciones aprendidas (incorporadas en PR #15):**
+- Las tareas se marcaron `[x]` sin ejecutar tests — 4 de 5 fallaban
+- Imports incorrectos (`config.settings` vs `app.core.config`) por diferencia de cwd
+- `List[str]` en pydantic-settings falla por JSON parse antes de validators
+- Middleware CORS no se puede patchear tras import — requiere test app dedicada
+- Se añadieron reglas de verificación a AGENTS.md, config.yaml, SKILL.md y tdd.instructions.md
 
-*Se completará con `/opsx:propose fix-dependency-injection`.*
+### Paso 7 — Definir workflow de desarrollo paralelo con worktrees (2026-04-06)
+
+**Problema:** El proyecto tiene múltiples items de deuda técnica independientes (DI, DataExplorer, token budget, etc.). Implementarlos secuencialmente es lento. Se necesita un patrón para paralelizar changes.
+
+**Decisión:** Adoptar git worktrees como mecanismo de aislamiento para aplicar múltiples OpenSpec changes en paralelo. Cada change se ejecuta en un worktree independiente con su propia rama.
+
+**Investigación realizada:** Se consultaron las siguientes fuentes para definir best practices:
+
+| Fuente | Aporte clave |
+|--------|-------------|
+| [Claude Code Worktree Complete Guide](https://claudelab.net/en/articles/claude-code/claude-code-worktree-guide) | `isolation: "worktree"` en subagentes, cleanup automático |
+| [Git Worktrees for Multi-Feature Development with AI Agents](https://www.nrmitchi.com/2025/10/using-git-worktrees-for-multi-feature-development-with-ai-agents/) | Patrón branch-per-worktree, límites prácticos |
+| [How Git Worktrees Changed My AI Agent Workflow (Nx Blog)](https://nx.dev/blog/git-worktrees-ai-agents) | Aislamiento de agentes, no ejecutar `git gc` con worktrees activos |
+| [One-Person Engineering Team: Claude Code Parallel Workflow](https://www.shareuhack.com/en/posts/claude-code-parallel-workflow-guide-2026) | Boris Cherny: 10-15 sesiones paralelas, recomendación práctica 3-5 |
+| [Claude Code Common Workflows (docs oficiales)](https://code.claude.com/docs/en/common-workflows) | Soporte nativo de worktrees en Claude Code CLI |
+| [Spec-Driven Development with AI (GitHub Blog)](https://github.blog/ai-and-ml/generative-ai/spec-driven-development-with-ai-get-started-with-a-new-open-source-toolkit/) | OpenSpec changes como unidades paralelas independientes |
+| [OpenSpec — Repositorio oficial](https://github.com/Fission-AI/OpenSpec) | Modelo de cambios aislados en `changes/` + merge de specs |
+
+**Reglas definidas:**
+1. Proponer en `develop` (secuencial) → aplicar en worktrees (paralelo) → PR por change → merge secuencial
+2. Solo paralelizar changes que no toquen los mismos ficheros
+3. Máximo 2-3 worktrees simultáneos
+4. Cada worktree necesita su propio install de dependencias si hay paquetes nuevos
+5. No ejecutar `git gc` con worktrees activos
+
+**Artefactos actualizados:**
+- `AGENTS.md` § "Parallel development with worktrees"
+- `.github/instructions/git-workflow.instructions.md` § "Worktrees para desarrollo paralelo"
+- `openspec/config.yaml` → nueva sección `parallel:`
+- `.claude/skills/openspec-apply-change/SKILL.md` → bloque "Parallel Apply with Worktrees"
+- `CLAUDE.md` → referencia a worktrees en sección OpenSpec governance
 
 ---
 
 ## 9. Referencias
 
+### OpenSpec
 - [OpenSpec — Repositorio oficial](https://github.com/Fission-AI/OpenSpec)
 - [OpenSpec — Getting Started](https://github.com/Fission-AI/OpenSpec/blob/main/docs/getting-started.md)
 - [OpenSpec — Workflows](https://github.com/Fission-AI/OpenSpec/blob/main/docs/workflows.md)
@@ -416,3 +455,13 @@ git push origin feature/openspec-governance
 - [OpenSpec — Customization](https://github.com/Fission-AI/OpenSpec/blob/main/docs/customization.md)
 - [OpenSpec — Supported Tools](https://github.com/Fission-AI/OpenSpec/blob/main/docs/supported-tools.md)
 - [OpenSpec — Concepts](https://github.com/Fission-AI/OpenSpec/blob/main/docs/concepts.md)
+- [Spec-Driven Development with AI (GitHub Blog)](https://github.blog/ai-and-ml/generative-ai/spec-driven-development-with-ai-get-started-with-a-new-open-source-toolkit/)
+
+### Git worktrees y desarrollo paralelo con agentes AI
+- [Claude Code Common Workflows (docs oficiales)](https://code.claude.com/docs/en/common-workflows)
+- [Claude Code Worktree Complete Guide (Claude Lab)](https://claudelab.net/en/articles/claude-code/claude-code-worktree-guide)
+- [Git Worktrees for Multi-Feature Development with AI Agents (Nick Mitchinson)](https://www.nrmitchi.com/2025/10/using-git-worktrees-for-multi-feature-development-with-ai-agents/)
+- [How Git Worktrees Changed My AI Agent Workflow (Nx Blog)](https://nx.dev/blog/git-worktrees-ai-agents)
+- [One-Person Engineering Team: Claude Code Parallel Workflow Guide](https://www.shareuhack.com/en/posts/claude-code-parallel-workflow-guide-2026)
+- [Mastering Git Worktrees with Claude Code (Medium)](https://medium.com/@dtunai/mastering-git-worktrees-with-claude-code-for-parallel-development-workflow-41dc91e645fe)
+- [Parallel Vibe Coding with Git Worktrees (Dan Does Code)](https://www.dandoescode.com/blog/parallel-vibe-coding-with-git-worktrees)

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -36,3 +36,10 @@ rules:
     - Run the full test suite before considering the change complete
     - If a test fails, fix it before moving to the next task
     - Verify module-level side effects (middleware, singletons) cannot be patched after import
+  parallel:
+    - Only parallelize changes that touch different files and layers
+    - Propose all changes on develop before launching parallel agents
+    - Each parallel apply runs in its own worktree with isolation: worktree
+    - Each worktree produces one PR against develop
+    - Merge PRs sequentially; rebase later PRs if conflicts arise
+    - Limit to 2-3 parallel worktrees to minimize merge conflict risk


### PR DESCRIPTION
## Summary
- Define rules and workflow for applying multiple OpenSpec changes in parallel using git worktrees
- Document research sources and decision rationale in the adoption plan
- Clean up duplicated steps in PLAN_OPENSPEC_ADOPTION.md and add steps 6-7

## Files changed
| File | Change |
|------|--------|
| `AGENTS.md` | New section "Parallel development with worktrees" — when/how/limits |
| `git-workflow.instructions.md` | 8 worktree rules + example flow |
| `openspec/config.yaml` | New `parallel:` rules section |
| `SKILL.md` (apply) | "Parallel Apply with Worktrees" block |
| `CLAUDE.md` | Worktree reference in OpenSpec governance |
| `PLAN_OPENSPEC_ADOPTION.md` | Step 6 (cors-hardening), Step 7 (worktree decision with sources), expanded references |

## Key decisions
- Propose on `develop` (sequential) → apply in worktrees (parallel) → one PR per change → merge sequential
- Max 2-3 parallel worktrees to minimize merge conflict risk
- Only parallelize changes that touch different files/layers
- Sources documented in adoption plan step 7 with per-source contribution

## Test plan
- [x] Documentation-only change — no code modified
- [x] Verified existing tests still pass (439 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)