### PR TITLE
fix(services): refactor DataExplorerService to use repository pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Replace direct `PostgresEventRepository()` / `SQLServerEventRepository()` instantiation in `health.py` and `capabilities.py` with FastAPI `Depends()` injection
 - Add `get_postgres_event_repository` and `get_sqlserver_event_repository` DI providers in `dependencies.py`
+- Refactor `DataExplorerService` to use injected `MatchRepository` instead of raw `psycopg2`/`pyodbc` connections, following the Repository Pattern
 
 ### Security
 - Replace `allow_origins=["*"]` with configurable `CORS_ORIGINS` env var in CORS middleware

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -65,9 +65,11 @@ def get_ingestion_service(
     return IngestionService(statsbomb=statsbomb)
 
 
-def get_data_explorer_service() -> DataExplorerService:
+def get_data_explorer_service(
+    match_repo: MatchRepository = Depends(get_match_repository),
+) -> DataExplorerService:
     """Dependency provider for DataExplorerService."""
-    return DataExplorerService()
+    return DataExplorerService(match_repo=match_repo)
 
 
 StatsBombSvc = Annotated[StatsBombService, Depends(get_statsbomb_service)]

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -8,6 +8,7 @@ changing business logic.
 
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from typing import Any
 
 from app.domain.entities import (
     Competition,
@@ -39,6 +40,16 @@ class BaseRepository(ABC):
 
         Returns:
             bool: True if connection is successful
+        """
+        pass
+
+    @abstractmethod
+    def get_tables_info(self) -> list[dict[str, Any]]:
+        """
+        Get table metadata (name, row_count, embedding_columns).
+
+        Returns:
+            List of dicts with table metadata
         """
         pass
 
@@ -86,6 +97,38 @@ class MatchRepository(BaseRepository):
 
         Returns:
             List of competitions
+        """
+        pass
+
+    @abstractmethod
+    def get_teams(
+        self, match_id: int | None = None, limit: int = 500
+    ) -> list[dict[str, Any]]:
+        """
+        Get team metadata (team_id, name, gender, country).
+
+        Args:
+            match_id: Optional filter by match ID
+            limit: Maximum number of results
+
+        Returns:
+            List of team dicts
+        """
+        pass
+
+    @abstractmethod
+    def get_players(
+        self, match_id: int | None = None, limit: int = 500
+    ) -> list[dict[str, Any]]:
+        """
+        Get player roster data (player_id, player_name, jersey_number, etc).
+
+        Args:
+            match_id: Optional filter by match ID
+            limit: Maximum number of results
+
+        Returns:
+            List of player dicts
         """
         pass
 

--- a/backend/app/repositories/postgres.py
+++ b/backend/app/repositories/postgres.py
@@ -183,6 +183,161 @@ class PostgresMatchRepository(MatchRepository):
             logger.error(f"Error fetching competitions: {e}")
             raise
 
+    def get_teams(
+        self, match_id: int | None = None, limit: int = 500
+    ) -> list[dict[str, Any]]:
+        """Get team metadata from matches."""
+        params: list[Any] = []
+        where_clause = ""
+        if match_id is not None:
+            where_clause = "WHERE match_id = %s"
+            params.append(match_id)
+
+        query = f"""
+            SELECT team_id, name, gender, country
+            FROM (
+                SELECT home_team_id AS team_id, home_team_name AS name, home_team_gender AS gender, home_team_country AS country
+                FROM matches
+                {where_clause}
+                UNION
+                SELECT away_team_id AS team_id, away_team_name AS name, away_team_gender AS gender, away_team_country AS country
+                FROM matches
+                {where_clause}
+            ) t
+            ORDER BY name
+            LIMIT %s
+        """
+        if match_id is not None:
+            params.extend([match_id])
+        params.append(limit)
+
+        try:
+            with self.get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(query, tuple(params))
+                    rows = cur.fetchall()
+                    return [
+                        {
+                            "team_id": int(row[0]),
+                            "name": row[1],
+                            "gender": row[2],
+                            "country": row[3],
+                        }
+                        for row in rows
+                        if row[0] is not None
+                    ]
+        except Exception as e:
+            logger.error(f"Error fetching teams: {e}")
+            raise
+
+    def get_players(
+        self, match_id: int | None = None, limit: int = 500
+    ) -> list[dict[str, Any]]:
+        """Get player roster data."""
+        try:
+            with self.get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT 1
+                        FROM information_schema.tables
+                        WHERE table_schema = 'public' AND table_name = %s
+                        """,
+                        ("players",),
+                    )
+                    if cur.fetchone() is None:
+                        return []
+
+            with self.get_connection() as conn:
+                with conn.cursor() as cur:
+                    if match_id is not None:
+                        cur.execute(
+                            """
+                            SELECT player_id, player_name, jersey_number, country_name, position_name, team_name
+                            FROM players
+                            WHERE match_id = %s
+                            ORDER BY player_name
+                            LIMIT %s
+                            """,
+                            (match_id, limit),
+                        )
+                    else:
+                        cur.execute(
+                            """
+                            SELECT player_id, player_name, jersey_number, country_name, position_name, team_name
+                            FROM players
+                            ORDER BY player_name
+                            LIMIT %s
+                            """,
+                            (limit,),
+                        )
+                    rows = cur.fetchall()
+                    return [
+                        {
+                            "player_id": int(row[0]),
+                            "player_name": row[1],
+                            "jersey_number": row[2],
+                            "country_name": row[3],
+                            "position_name": row[4],
+                            "team_name": row[5],
+                        }
+                        for row in rows
+                        if row[0] is not None
+                    ]
+        except Exception as e:
+            logger.error(f"Error fetching players: {e}")
+            raise
+
+    def get_tables_info(self) -> list[dict[str, Any]]:
+        """Get table metadata for PostgreSQL."""
+        try:
+            with self.get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT table_name
+                        FROM information_schema.tables
+                        WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+                        ORDER BY table_name
+                        """
+                    )
+                    table_names = [r[0] for r in cur.fetchall()]
+
+                    cur.execute(
+                        """
+                        SELECT table_name, column_name
+                        FROM information_schema.columns
+                        WHERE table_schema = 'public'
+                          AND (
+                            udt_name = 'vector'
+                            OR column_name LIKE '%embedding%'
+                          )
+                        ORDER BY table_name, column_name
+                        """
+                    )
+
+                    embedding_map: dict[str, list[str]] = {}
+                    for table_name, column_name in cur.fetchall():
+                        embedding_map.setdefault(table_name, []).append(column_name)
+
+                    info: list[dict[str, Any]] = []
+                    for table_name in table_names:
+                        cur.execute(f'SELECT COUNT(*) FROM "{table_name}"')
+                        row_count = int(cur.fetchone()[0] or 0)
+
+                        info.append(
+                            {
+                                "table": table_name,
+                                "row_count": row_count,
+                                "embedding_columns": embedding_map.get(table_name, []),
+                            }
+                        )
+
+                    return info
+        except Exception as e:
+            logger.error(f"Error fetching tables info: {e}")
+            raise
+
     def _row_to_match(self, row: dict[str, Any]) -> Match:
         """Convert database row to Match entity."""
         competition = Competition(
@@ -283,6 +438,56 @@ class PostgresEventRepository(EventRepository):
         except Exception as e:
             logger.error(f"Connection test failed: {e}")
             return False
+
+    def get_tables_info(self) -> list[dict[str, Any]]:
+        """Get table metadata for PostgreSQL."""
+        try:
+            with self.get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT table_name
+                        FROM information_schema.tables
+                        WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+                        ORDER BY table_name
+                        """
+                    )
+                    table_names = [r[0] for r in cur.fetchall()]
+
+                    cur.execute(
+                        """
+                        SELECT table_name, column_name
+                        FROM information_schema.columns
+                        WHERE table_schema = 'public'
+                          AND (
+                            udt_name = 'vector'
+                            OR column_name LIKE '%embedding%'
+                          )
+                        ORDER BY table_name, column_name
+                        """
+                    )
+
+                    embedding_map: dict[str, list[str]] = {}
+                    for table_name, column_name in cur.fetchall():
+                        embedding_map.setdefault(table_name, []).append(column_name)
+
+                    info: list[dict[str, Any]] = []
+                    for table_name in table_names:
+                        cur.execute(f'SELECT COUNT(*) FROM "{table_name}"')
+                        row_count = int(cur.fetchone()[0] or 0)
+
+                        info.append(
+                            {
+                                "table": table_name,
+                                "row_count": row_count,
+                                "embedding_columns": embedding_map.get(table_name, []),
+                            }
+                        )
+
+                    return info
+        except Exception as e:
+            logger.error(f"Error fetching tables info: {e}")
+            raise
 
     def get_events_by_match(
         self, match_id: int, limit: int | None = None

--- a/backend/app/repositories/sqlserver.py
+++ b/backend/app/repositories/sqlserver.py
@@ -7,6 +7,7 @@ SQL Server's VECTOR type for similarity search.
 
 import logging
 from contextlib import contextmanager
+from typing import Any
 
 import pyodbc
 
@@ -185,6 +186,156 @@ class SQLServerMatchRepository(MatchRepository):
             logger.error(f"Error fetching competitions: {e}")
             raise
 
+    def get_teams(
+        self, match_id: int | None = None, limit: int = 500
+    ) -> list[dict[str, Any]]:
+        """Get team metadata from matches."""
+        params: list[Any] = []
+        where_clause = ""
+        if match_id is not None:
+            where_clause = "WHERE match_id = ?"
+            params.append(match_id)
+
+        query = f"""
+            SELECT TOP (?) team_id, name, gender, country
+            FROM (
+                SELECT home_team_id AS team_id, home_team_name AS name, home_team_gender AS gender, home_team_country AS country
+                FROM matches
+                {where_clause}
+                UNION
+                SELECT away_team_id AS team_id, away_team_name AS name, away_team_gender AS gender, away_team_country AS country
+                FROM matches
+                {where_clause}
+            ) t
+            ORDER BY name
+        """
+        args: list[Any] = [limit]
+        args.extend(params)
+        if match_id is not None:
+            args.extend([match_id])
+
+        try:
+            with self.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(query, tuple(args))
+                rows = cursor.fetchall()
+                return [
+                    {
+                        "team_id": int(row[0]),
+                        "name": row[1],
+                        "gender": row[2],
+                        "country": row[3],
+                    }
+                    for row in rows
+                    if row[0] is not None
+                ]
+        except Exception as e:
+            logger.error(f"Error fetching teams: {e}")
+            raise
+
+    def get_players(
+        self, match_id: int | None = None, limit: int = 500
+    ) -> list[dict[str, Any]]:
+        """Get player roster data."""
+        try:
+            with self.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    SELECT 1
+                    FROM sys.tables
+                    WHERE name = ?
+                    """,
+                    ("players",),
+                )
+                if cursor.fetchone() is None:
+                    return []
+
+            with self.get_connection() as conn:
+                cursor = conn.cursor()
+                if match_id is not None:
+                    cursor.execute(
+                        """
+                        SELECT TOP (?) player_id, player_name, jersey_number, country_name, position_name, team_name
+                        FROM players
+                        WHERE match_id = ?
+                        ORDER BY player_name
+                        """,
+                        (limit, match_id),
+                    )
+                else:
+                    cursor.execute(
+                        """
+                        SELECT TOP (?) player_id, player_name, jersey_number, country_name, position_name, team_name
+                        FROM players
+                        ORDER BY player_name
+                        """,
+                        (limit,),
+                    )
+                rows = cursor.fetchall()
+                return [
+                    {
+                        "player_id": int(row[0]),
+                        "player_name": row[1],
+                        "jersey_number": row[2],
+                        "country_name": row[3],
+                        "position_name": row[4],
+                        "team_name": row[5],
+                    }
+                    for row in rows
+                    if row[0] is not None
+                ]
+        except Exception as e:
+            logger.error(f"Error fetching players: {e}")
+            raise
+
+    def get_tables_info(self) -> list[dict[str, Any]]:
+        """Get table metadata for SQL Server."""
+        try:
+            with self.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    SELECT name
+                    FROM sys.tables
+                    ORDER BY name
+                    """
+                )
+                table_names = [r[0] for r in cursor.fetchall()]
+
+                cursor.execute(
+                    """
+                    SELECT t.name, c.name
+                    FROM sys.columns c
+                    JOIN sys.tables t ON c.object_id = t.object_id
+                    LEFT JOIN sys.types ty ON c.user_type_id = ty.user_type_id
+                    WHERE ty.name = 'vector' OR c.name LIKE '%embedding%'
+                    ORDER BY t.name, c.name
+                    """
+                )
+
+                embedding_map: dict[str, list[str]] = {}
+                for table_name, column_name in cursor.fetchall():
+                    embedding_map.setdefault(table_name, []).append(column_name)
+
+                info: list[dict[str, Any]] = []
+                for table_name in table_names:
+                    cursor.execute(f"SELECT COUNT(*) FROM [{table_name}]")
+                    row_count = int(cursor.fetchone()[0] or 0)
+
+                    info.append(
+                        {
+                            "table": table_name,
+                            "row_count": row_count,
+                            "embedding_columns": embedding_map.get(table_name, []),
+                        }
+                    )
+
+                return info
+        except Exception as e:
+            logger.error(f"Error fetching tables info: {e}")
+            raise
+
     def _row_to_match(self, row) -> Match:
         """Convert database row to Match entity."""
         competition = Competition(
@@ -292,6 +443,53 @@ class SQLServerEventRepository(EventRepository):
         except Exception as e:
             logger.error(f"Connection test failed: {e}")
             return False
+
+    def get_tables_info(self) -> list[dict[str, Any]]:
+        """Get table metadata for SQL Server."""
+        try:
+            with self.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    SELECT name
+                    FROM sys.tables
+                    ORDER BY name
+                    """
+                )
+                table_names = [r[0] for r in cursor.fetchall()]
+
+                cursor.execute(
+                    """
+                    SELECT t.name, c.name
+                    FROM sys.columns c
+                    JOIN sys.tables t ON c.object_id = t.object_id
+                    LEFT JOIN sys.types ty ON c.user_type_id = ty.user_type_id
+                    WHERE ty.name = 'vector' OR c.name LIKE '%embedding%'
+                    ORDER BY t.name, c.name
+                    """
+                )
+
+                embedding_map: dict[str, list[str]] = {}
+                for table_name, column_name in cursor.fetchall():
+                    embedding_map.setdefault(table_name, []).append(column_name)
+
+                info: list[dict[str, Any]] = []
+                for table_name in table_names:
+                    cursor.execute(f"SELECT COUNT(*) FROM [{table_name}]")
+                    row_count = int(cursor.fetchone()[0] or 0)
+
+                    info.append(
+                        {
+                            "table": table_name,
+                            "row_count": row_count,
+                            "embedding_columns": embedding_map.get(table_name, []),
+                        }
+                    )
+
+                return info
+        except Exception as e:
+            logger.error(f"Error fetching tables info: {e}")
+            raise
 
     def get_events_by_match(
         self, match_id: int, limit: int | None = None

--- a/backend/app/services/data_explorer_service.py
+++ b/backend/app/services/data_explorer_service.py
@@ -2,277 +2,38 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
 from typing import Any
 
-import psycopg2
-import pyodbc
-
-from app.core.capabilities import normalize_source
-from app.core.config import get_settings
+from app.repositories.base import MatchRepository
 
 
 class DataExplorerService:
-    """Read-only service for operational data exploration endpoints."""
+    """Read-only service for operational data exploration endpoints.
 
-    def __init__(self):
-        self.settings = get_settings()
+    Delegates all database access to injected repository instances.
+    """
 
-    @contextmanager
-    def _get_connection(self, source: str):
-        src = normalize_source(source)
-        conn = None
-        try:
-            if src == "postgres":
-                conn = psycopg2.connect(
-                    host=self.settings.database.postgres_host,
-                    database=self.settings.database.postgres_database,
-                    user=self.settings.database.postgres_user,
-                    password=self.settings.database.postgres_password,
-                )
-            elif src == "sqlserver":
-                conn = pyodbc.connect(
-                    "DRIVER={ODBC Driver 18 for SQL Server};"
-                    f"SERVER={self.settings.database.sqlserver_host};"
-                    f"DATABASE={self.settings.database.sqlserver_database};"
-                    f"UID={self.settings.database.sqlserver_user};"
-                    f"PWD={self.settings.database.sqlserver_password};"
-                    "TrustServerCertificate=yes;"
-                )
-            else:
-                raise ValueError(f"Unsupported source: {source}")
-            yield conn
-        finally:
-            if conn:
-                conn.close()
+    def __init__(self, match_repo: MatchRepository | None = None):
+        self._match_repo = match_repo
 
     def get_teams(
         self, source: str, match_id: int | None = None, limit: int = 500
     ) -> list[dict[str, Any]]:
-        src = normalize_source(source)
-        with self._get_connection(src) as conn:
-            cur = conn.cursor()
-
-            if src == "postgres":
-                params: list[Any] = []
-                where_clause = ""
-                if match_id is not None:
-                    where_clause = "WHERE match_id = %s"
-                    params.append(match_id)
-
-                query = f"""
-                    SELECT team_id, name, gender, country
-                    FROM (
-                        SELECT home_team_id AS team_id, home_team_name AS name, home_team_gender AS gender, home_team_country AS country
-                        FROM matches
-                        {where_clause}
-                        UNION
-                        SELECT away_team_id AS team_id, away_team_name AS name, away_team_gender AS gender, away_team_country AS country
-                        FROM matches
-                        {where_clause}
-                    ) t
-                    ORDER BY name
-                    LIMIT %s
-                """
-                if match_id is not None:
-                    params.extend([match_id])
-                params.append(limit)
-                cur.execute(query, tuple(params))
-            else:
-                params = []
-                where_clause = ""
-                if match_id is not None:
-                    where_clause = "WHERE match_id = ?"
-                    params.append(match_id)
-
-                query = f"""
-                    SELECT TOP (?) team_id, name, gender, country
-                    FROM (
-                        SELECT home_team_id AS team_id, home_team_name AS name, home_team_gender AS gender, home_team_country AS country
-                        FROM matches
-                        {where_clause}
-                        UNION
-                        SELECT away_team_id AS team_id, away_team_name AS name, away_team_gender AS gender, away_team_country AS country
-                        FROM matches
-                        {where_clause}
-                    ) t
-                    ORDER BY name
-                """
-                args: list[Any] = [limit]
-                args.extend(params)
-                if match_id is not None:
-                    args.extend([match_id])
-                cur.execute(query, tuple(args))
-
-            rows = cur.fetchall()
-            return [
-                {
-                    "team_id": int(row[0]),
-                    "name": row[1],
-                    "gender": row[2],
-                    "country": row[3],
-                }
-                for row in rows
-                if row[0] is not None
-            ]
-
-    def _table_exists(self, conn, source: str, table_name: str) -> bool:
-        src = normalize_source(source)
-        cur = conn.cursor()
-        if src == "postgres":
-            cur.execute(
-                """
-                SELECT 1
-                FROM information_schema.tables
-                WHERE table_schema = 'public' AND table_name = %s
-                """,
-                (table_name,),
-            )
-        else:
-            cur.execute(
-                """
-                SELECT 1
-                FROM sys.tables
-                WHERE name = ?
-                """,
-                (table_name,),
-            )
-        return cur.fetchone() is not None
+        """Get team metadata, delegating to the match repository."""
+        if self._match_repo is None:
+            raise RuntimeError("MatchRepository not injected")
+        return self._match_repo.get_teams(match_id=match_id, limit=limit)
 
     def get_players(
         self, source: str, match_id: int | None = None, limit: int = 500
     ) -> list[dict[str, Any]]:
-        src = normalize_source(source)
-        with self._get_connection(src) as conn:
-            if not self._table_exists(conn, src, "players"):
-                return []
-
-            cur = conn.cursor()
-            if src == "postgres":
-                if match_id is not None:
-                    cur.execute(
-                        """
-                        SELECT player_id, player_name, jersey_number, country_name, position_name, team_name
-                        FROM players
-                        WHERE match_id = %s
-                        ORDER BY player_name
-                        LIMIT %s
-                        """,
-                        (match_id, limit),
-                    )
-                else:
-                    cur.execute(
-                        """
-                        SELECT player_id, player_name, jersey_number, country_name, position_name, team_name
-                        FROM players
-                        ORDER BY player_name
-                        LIMIT %s
-                        """,
-                        (limit,),
-                    )
-            else:
-                if match_id is not None:
-                    cur.execute(
-                        """
-                        SELECT TOP (?) player_id, player_name, jersey_number, country_name, position_name, team_name
-                        FROM players
-                        WHERE match_id = ?
-                        ORDER BY player_name
-                        """,
-                        (limit, match_id),
-                    )
-                else:
-                    cur.execute(
-                        """
-                        SELECT TOP (?) player_id, player_name, jersey_number, country_name, position_name, team_name
-                        FROM players
-                        ORDER BY player_name
-                        """,
-                        (limit,),
-                    )
-
-            rows = cur.fetchall()
-            return [
-                {
-                    "player_id": int(row[0]),
-                    "player_name": row[1],
-                    "jersey_number": row[2],
-                    "country_name": row[3],
-                    "position_name": row[4],
-                    "team_name": row[5],
-                }
-                for row in rows
-                if row[0] is not None
-            ]
+        """Get player roster data, delegating to the match repository."""
+        if self._match_repo is None:
+            raise RuntimeError("MatchRepository not injected")
+        return self._match_repo.get_players(match_id=match_id, limit=limit)
 
     def get_tables_info(self, source: str) -> list[dict[str, Any]]:
-        src = normalize_source(source)
-        with self._get_connection(src) as conn:
-            cur = conn.cursor()
-
-            if src == "postgres":
-                cur.execute(
-                    """
-                    SELECT table_name
-                    FROM information_schema.tables
-                    WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
-                    ORDER BY table_name
-                    """
-                )
-                table_names = [r[0] for r in cur.fetchall()]
-
-                cur.execute(
-                    """
-                    SELECT table_name, column_name
-                    FROM information_schema.columns
-                    WHERE table_schema = 'public'
-                      AND (
-                        udt_name = 'vector'
-                        OR column_name LIKE '%embedding%'
-                      )
-                    ORDER BY table_name, column_name
-                    """
-                )
-            else:
-                cur.execute(
-                    """
-                    SELECT name
-                    FROM sys.tables
-                    ORDER BY name
-                    """
-                )
-                table_names = [r[0] for r in cur.fetchall()]
-
-                cur.execute(
-                    """
-                    SELECT t.name, c.name
-                    FROM sys.columns c
-                    JOIN sys.tables t ON c.object_id = t.object_id
-                    LEFT JOIN sys.types ty ON c.user_type_id = ty.user_type_id
-                    WHERE ty.name = 'vector' OR c.name LIKE '%embedding%'
-                    ORDER BY t.name, c.name
-                    """
-                )
-
-            embedding_map: dict[str, list[str]] = {}
-            for table_name, column_name in cur.fetchall():
-                embedding_map.setdefault(table_name, []).append(column_name)
-
-            info: list[dict[str, Any]] = []
-            for table_name in table_names:
-                count_cursor = conn.cursor()
-                if src == "postgres":
-                    count_cursor.execute(f'SELECT COUNT(*) FROM "{table_name}"')
-                else:
-                    count_cursor.execute(f"SELECT COUNT(*) FROM [{table_name}]")
-                row_count = int(count_cursor.fetchone()[0] or 0)
-
-                info.append(
-                    {
-                        "table": table_name,
-                        "row_count": row_count,
-                        "embedding_columns": embedding_map.get(table_name, []),
-                    }
-                )
-
-            return info
+        """Get table metadata, delegating to the match repository."""
+        if self._match_repo is None:
+            raise RuntimeError("MatchRepository not injected")
+        return self._match_repo.get_tables_info()

--- a/backend/tests/unit/test_dependencies_and_explorer_service.py
+++ b/backend/tests/unit/test_dependencies_and_explorer_service.py
@@ -1,10 +1,12 @@
 """Unit tests for core/dependencies.py and DataExplorerService."""
 
+import inspect
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from app.core.dependencies import get_repository_factory, get_match_repository, get_event_repository
+from app.repositories.base import MatchRepository, EventRepository
 from app.repositories.postgres import PostgresRepositoryFactory
 from app.repositories.sqlserver import SQLServerRepositoryFactory
 
@@ -33,152 +35,184 @@ class TestGetRepositoryFactory:
 
 class TestGetMatchRepository:
     def test_returns_match_repo_for_postgres(self):
-        from app.repositories.base import MatchRepository
         repo = get_match_repository("postgres")
         assert isinstance(repo, MatchRepository)
 
     def test_returns_match_repo_for_sqlserver(self):
-        from app.repositories.base import MatchRepository
         repo = get_match_repository("sqlserver")
         assert isinstance(repo, MatchRepository)
 
 
 class TestGetEventRepository:
     def test_returns_event_repo_for_postgres(self):
-        from app.repositories.base import EventRepository
         repo = get_event_repository("postgres")
         assert isinstance(repo, EventRepository)
 
     def test_returns_event_repo_for_sqlserver(self):
-        from app.repositories.base import EventRepository
         repo = get_event_repository("sqlserver")
         assert isinstance(repo, EventRepository)
 
 
 # ---------------------------------------------------------------------------
-# DataExplorerService tests with mocked connections
+# DataExplorerService — repository-based tests
 # ---------------------------------------------------------------------------
 
 class TestDataExplorerServiceGetTeams:
-    def _make_mock_conn(self, rows):
-        cursor = MagicMock()
-        cursor.fetchall.return_value = rows
-        conn = MagicMock()
-        conn.cursor.return_value = cursor
-        return conn, cursor
+    """Tests for get_teams delegating to MatchRepository."""
 
-    @patch("app.services.data_explorer_service.psycopg2.connect")
-    def test_get_teams_postgres_returns_list(self, mock_connect):
+    def test_get_teams_delegates_to_repository(self):
         from app.services.data_explorer_service import DataExplorerService
 
-        svc = DataExplorerService()
-        row = (100, "Spain", "male", "Spain")
-        conn, cursor = self._make_mock_conn([row])
+        mock_repo = MagicMock(spec=MatchRepository)
+        mock_repo.get_teams.return_value = [
+            {"team_id": 100, "name": "Spain", "gender": "male", "country": "Spain"},
+        ]
 
-        with patch.object(svc, "_get_connection") as mock_gc:
-            mock_gc.return_value.__enter__ = MagicMock(return_value=conn)
-            mock_gc.return_value.__exit__ = MagicMock(return_value=False)
-            results = svc.get_teams(source="postgres")
+        svc = DataExplorerService(match_repo=mock_repo)
+        results = svc.get_teams(source="postgres")
 
+        mock_repo.get_teams.assert_called_once_with(match_id=None, limit=500)
         assert len(results) == 1
         assert results[0]["team_id"] == 100
         assert results[0]["name"] == "Spain"
 
-    @patch("app.services.data_explorer_service.psycopg2.connect")
-    def test_get_teams_postgres_with_match_id(self, mock_connect):
+    def test_get_teams_passes_match_id_to_repository(self):
         from app.services.data_explorer_service import DataExplorerService
 
-        svc = DataExplorerService()
-        row = (100, "Spain", "male", "Spain")
-        conn, cursor = self._make_mock_conn([row])
+        mock_repo = MagicMock(spec=MatchRepository)
+        mock_repo.get_teams.return_value = [
+            {"team_id": 100, "name": "Spain", "gender": "male", "country": "Spain"},
+        ]
 
-        with patch.object(svc, "_get_connection") as mock_gc:
-            mock_gc.return_value.__enter__ = MagicMock(return_value=conn)
-            mock_gc.return_value.__exit__ = MagicMock(return_value=False)
-            results = svc.get_teams(source="postgres", match_id=3943043)
+        svc = DataExplorerService(match_repo=mock_repo)
+        results = svc.get_teams(source="postgres", match_id=3943043)
 
+        mock_repo.get_teams.assert_called_once_with(match_id=3943043, limit=500)
         assert len(results) == 1
 
-    @patch("app.services.data_explorer_service.pyodbc.connect")
-    def test_get_teams_sqlserver_returns_list(self, mock_connect):
+    def test_get_teams_passes_limit_to_repository(self):
         from app.services.data_explorer_service import DataExplorerService
 
-        svc = DataExplorerService()
-        row = (200, "England", "male", "England")
-        conn, cursor = self._make_mock_conn([row])
+        mock_repo = MagicMock(spec=MatchRepository)
+        mock_repo.get_teams.return_value = []
 
-        with patch.object(svc, "_get_connection") as mock_gc:
-            mock_gc.return_value.__enter__ = MagicMock(return_value=conn)
-            mock_gc.return_value.__exit__ = MagicMock(return_value=False)
-            results = svc.get_teams(source="sqlserver")
+        svc = DataExplorerService(match_repo=mock_repo)
+        svc.get_teams(source="postgres", limit=10)
 
-        assert len(results) == 1
-        assert results[0]["name"] == "England"
+        mock_repo.get_teams.assert_called_once_with(match_id=None, limit=10)
 
-    @patch("app.services.data_explorer_service.psycopg2.connect")
-    def test_get_teams_skips_rows_with_none_team_id(self, mock_connect):
+    def test_get_teams_returns_empty_list_from_repository(self):
         from app.services.data_explorer_service import DataExplorerService
 
-        svc = DataExplorerService()
-        rows = [(None, "Unknown", "male", "Unknown"), (100, "Spain", "male", "Spain")]
-        conn, cursor = self._make_mock_conn(rows)
+        mock_repo = MagicMock(spec=MatchRepository)
+        mock_repo.get_teams.return_value = []
 
-        with patch.object(svc, "_get_connection") as mock_gc:
-            mock_gc.return_value.__enter__ = MagicMock(return_value=conn)
-            mock_gc.return_value.__exit__ = MagicMock(return_value=False)
-            results = svc.get_teams(source="postgres")
-
-        assert len(results) == 1
-        assert results[0]["team_id"] == 100
-
-
-class TestDataExplorerServiceGetPlayers:
-    def _make_mock_conn(self, rows, table_exists=True):
-        cursor = MagicMock()
-        cursor.fetchall.return_value = rows
-        # table exists check: fetchone returns a row or None
-        cursor.fetchone.return_value = (1,) if table_exists else None
-        conn = MagicMock()
-        conn.cursor.return_value = cursor
-        return conn, cursor
-
-    @patch("app.services.data_explorer_service.psycopg2.connect")
-    def test_get_players_returns_empty_when_no_table(self, mock_connect):
-        from app.services.data_explorer_service import DataExplorerService
-
-        svc = DataExplorerService()
-        conn, cursor = self._make_mock_conn(rows=[], table_exists=False)
-
-        with patch.object(svc, "_get_connection") as mock_gc:
-            mock_gc.return_value.__enter__ = MagicMock(return_value=conn)
-            mock_gc.return_value.__exit__ = MagicMock(return_value=False)
-            results = svc.get_players(source="postgres")
+        svc = DataExplorerService(match_repo=mock_repo)
+        results = svc.get_teams(source="postgres")
 
         assert results == []
 
-    @patch("app.services.data_explorer_service.psycopg2.connect")
-    def test_get_players_postgres_returns_list(self, mock_connect):
+
+class TestDataExplorerServiceGetPlayers:
+    """Tests for get_players delegating to MatchRepository."""
+
+    def test_get_players_delegates_to_repository(self):
         from app.services.data_explorer_service import DataExplorerService
 
-        svc = DataExplorerService()
-        player_row = (1, "Rodri", 16, "Spain", "Defensive Midfield", "Spain")
-        conn, cursor = self._make_mock_conn(rows=[player_row], table_exists=True)
-        # first fetchone for table check, then fetchall for data
-        cursor.fetchone.return_value = (1,)
+        mock_repo = MagicMock(spec=MatchRepository)
+        mock_repo.get_players.return_value = [
+            {
+                "player_id": 1,
+                "player_name": "Rodri",
+                "jersey_number": 16,
+                "country_name": "Spain",
+                "position_name": "Defensive Midfield",
+                "team_name": "Spain",
+            },
+        ]
 
-        with patch.object(svc, "_table_exists") as mock_te, patch.object(svc, "_get_connection") as mock_gc:
-            mock_te.return_value = True
-            mock_gc.return_value.__enter__ = MagicMock(return_value=conn)
-            mock_gc.return_value.__exit__ = MagicMock(return_value=False)
-            results = svc.get_players(source="postgres")
+        svc = DataExplorerService(match_repo=mock_repo)
+        results = svc.get_players(source="postgres")
 
+        mock_repo.get_players.assert_called_once_with(match_id=None, limit=500)
         assert len(results) == 1
         assert results[0]["player_name"] == "Rodri"
 
+    def test_get_players_passes_match_id_to_repository(self):
+        from app.services.data_explorer_service import DataExplorerService
+
+        mock_repo = MagicMock(spec=MatchRepository)
+        mock_repo.get_players.return_value = []
+
+        svc = DataExplorerService(match_repo=mock_repo)
+        svc.get_players(source="postgres", match_id=3943043)
+
+        mock_repo.get_players.assert_called_once_with(match_id=3943043, limit=500)
+
+    def test_get_players_returns_empty_list_from_repository(self):
+        from app.services.data_explorer_service import DataExplorerService
+
+        mock_repo = MagicMock(spec=MatchRepository)
+        mock_repo.get_players.return_value = []
+
+        svc = DataExplorerService(match_repo=mock_repo)
+        results = svc.get_players(source="postgres")
+
+        assert results == []
+
+
+class TestDataExplorerServiceGetTablesInfo:
+    """Tests for get_tables_info delegating to MatchRepository."""
+
+    def test_get_tables_info_delegates_to_repository(self):
+        from app.services.data_explorer_service import DataExplorerService
+
+        mock_repo = MagicMock(spec=MatchRepository)
+        mock_repo.get_tables_info.return_value = [
+            {"table": "matches", "row_count": 42, "embedding_columns": []},
+        ]
+
+        svc = DataExplorerService(match_repo=mock_repo)
+        results = svc.get_tables_info(source="postgres")
+
+        mock_repo.get_tables_info.assert_called_once()
+        assert len(results) == 1
+        assert results[0]["table"] == "matches"
+        assert results[0]["row_count"] == 42
+
+    def test_get_tables_info_returns_multiple_tables(self):
+        from app.services.data_explorer_service import DataExplorerService
+
+        mock_repo = MagicMock(spec=MatchRepository)
+        mock_repo.get_tables_info.return_value = [
+            {"table": "matches", "row_count": 42, "embedding_columns": []},
+            {"table": "events_details__quarter_minute", "row_count": 1000, "embedding_columns": ["summary_embedding_ada_002"]},
+        ]
+
+        svc = DataExplorerService(match_repo=mock_repo)
+        results = svc.get_tables_info(source="postgres")
+
+        assert len(results) == 2
+
+
+class TestDataExplorerServiceNoPsycopg2Import:
+    """Verify the service has no raw driver imports."""
+
+    def test_service_has_no_psycopg2_import(self):
+        import app.services.data_explorer_service as module
+
+        source = inspect.getsource(module)
+        assert "psycopg2" not in source, "DataExplorerService must not import psycopg2"
+
+    def test_service_has_no_pyodbc_import(self):
+        import app.services.data_explorer_service as module
+
+        source = inspect.getsource(module)
+        assert "pyodbc" not in source, "DataExplorerService must not import pyodbc"
+
 
 # ---------------------------------------------------------------------------
-# TDD RED: DI providers for IngestionService, StatsBombService, DataExplorerService
-# These tests FAIL until the providers are added to core/dependencies.py
+# DI providers for IngestionService, StatsBombService, DataExplorerService
 # ---------------------------------------------------------------------------
 
 class TestGetIngestionServiceProvider:
@@ -223,6 +257,14 @@ class TestGetDataExplorerServiceProvider:
         from app.services.data_explorer_service import DataExplorerService
 
         svc = get_data_explorer_service()
+        assert isinstance(svc, DataExplorerService)
+
+    def test_get_data_explorer_service_accepts_match_repo_injection(self):
+        from app.core.dependencies import get_data_explorer_service
+        from app.services.data_explorer_service import DataExplorerService
+
+        mock_repo = MagicMock(spec=MatchRepository)
+        svc = get_data_explorer_service(match_repo=mock_repo)
         assert isinstance(svc, DataExplorerService)
 
     def test_explorer_svc_alias_is_annotated(self):

--- a/backend/tests/unit/test_repository_explorer_methods.py
+++ b/backend/tests/unit/test_repository_explorer_methods.py
@@ -1,0 +1,328 @@
+"""Unit tests for repository get_teams, get_players, get_tables_info methods."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.repositories.postgres import PostgresMatchRepository, PostgresEventRepository
+from app.repositories.sqlserver import SQLServerMatchRepository, SQLServerEventRepository
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def _mock_pg_connection(rows, fetchall_sequence=None):
+    """Create a mock Postgres connection context with cursor returning rows."""
+    cursor = MagicMock()
+    if fetchall_sequence is not None:
+        cursor.fetchall = MagicMock(side_effect=fetchall_sequence)
+    else:
+        cursor.fetchall.return_value = rows
+    cursor.fetchone.return_value = rows[0] if rows else None
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    yield conn, cursor
+
+
+@contextmanager
+def _mock_sql_connection(rows, fetchall_sequence=None):
+    """Create a mock SQL Server connection context with cursor returning rows."""
+    cursor = MagicMock()
+    if fetchall_sequence is not None:
+        cursor.fetchall = MagicMock(side_effect=fetchall_sequence)
+    else:
+        cursor.fetchall.return_value = rows
+    cursor.fetchone.return_value = rows[0] if rows else None
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    yield conn, cursor
+
+
+# ---------------------------------------------------------------------------
+# PostgresMatchRepository — get_teams
+# ---------------------------------------------------------------------------
+
+class TestPostgresGetTeams:
+    def test_get_teams_returns_list_of_dicts(self):
+        repo = PostgresMatchRepository.__new__(PostgresMatchRepository)
+        rows = [(1, "Spain", "male", "Spain"), (2, "England", "male", "England")]
+        with _mock_pg_connection(rows) as (conn, _):
+            repo.get_connection = MagicMock(return_value=contextmanager(lambda: (yield conn))())
+            result = repo.get_teams()
+        assert len(result) == 2
+        assert result[0]["team_id"] == 1
+        assert result[0]["name"] == "Spain"
+
+    def test_get_teams_filters_none_rows(self):
+        repo = PostgresMatchRepository.__new__(PostgresMatchRepository)
+        rows = [(1, "Spain", "male", "Spain"), (None, None, None, None)]
+        with _mock_pg_connection(rows) as (conn, _):
+            repo.get_connection = MagicMock(return_value=contextmanager(lambda: (yield conn))())
+            result = repo.get_teams()
+        assert len(result) == 1
+
+    def test_get_teams_with_match_id_filter(self):
+        repo = PostgresMatchRepository.__new__(PostgresMatchRepository)
+        rows = [(1, "Spain", "male", "Spain")]
+        with _mock_pg_connection(rows) as (conn, cursor):
+            repo.get_connection = MagicMock(return_value=contextmanager(lambda: (yield conn))())
+            result = repo.get_teams(match_id=123)
+        assert len(result) == 1
+        assert cursor.execute.called
+
+
+# ---------------------------------------------------------------------------
+# PostgresMatchRepository — get_players
+# ---------------------------------------------------------------------------
+
+class TestPostgresGetPlayers:
+    def test_get_players_returns_list_when_table_exists(self):
+        repo = PostgresMatchRepository.__new__(PostgresMatchRepository)
+        table_check_row = (1,)
+        player_rows = [(10, "Pedri", 8, "Spain", "Midfielder", "Spain")]
+
+        call_count = [0]
+        conns = []
+
+        def make_conn(fetchone_val, fetchall_val):
+            cursor = MagicMock()
+            cursor.fetchone.return_value = fetchone_val
+            cursor.fetchall.return_value = fetchall_val
+            cursor.__enter__ = MagicMock(return_value=cursor)
+            cursor.__exit__ = MagicMock(return_value=False)
+            c = MagicMock()
+            c.cursor.return_value = cursor
+            c.__enter__ = MagicMock(return_value=c)
+            c.__exit__ = MagicMock(return_value=False)
+            return c
+
+        conn1 = make_conn(table_check_row, [])
+        conn2 = make_conn(None, player_rows)
+
+        def get_conn_side_effect():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return contextmanager(lambda: (yield conn1))()
+            return contextmanager(lambda: (yield conn2))()
+
+        repo.get_connection = MagicMock(side_effect=get_conn_side_effect)
+        result = repo.get_players()
+        assert len(result) == 1
+        assert result[0]["player_name"] == "Pedri"
+
+    def test_get_players_returns_empty_when_table_missing(self):
+        repo = PostgresMatchRepository.__new__(PostgresMatchRepository)
+        cursor = MagicMock()
+        cursor.fetchone.return_value = None
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        repo.get_connection = MagicMock(return_value=contextmanager(lambda: (yield conn))())
+        result = repo.get_players()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# PostgresMatchRepository — get_tables_info
+# ---------------------------------------------------------------------------
+
+class TestPostgresGetTablesInfo:
+    def test_get_tables_info_returns_table_metadata(self):
+        repo = PostgresMatchRepository.__new__(PostgresMatchRepository)
+
+        cursor = MagicMock()
+        call_count = [0]
+
+        def fetchall_side_effect():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [("matches",), ("events",)]
+            elif call_count[0] == 2:
+                return [("events", "embedding")]
+            return []
+
+        def fetchone_side_effect():
+            return (42,)
+
+        cursor.fetchall = MagicMock(side_effect=fetchall_side_effect)
+        cursor.fetchone = MagicMock(side_effect=fetchone_side_effect)
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        repo.get_connection = MagicMock(return_value=contextmanager(lambda: (yield conn))())
+        result = repo.get_tables_info()
+        assert len(result) == 2
+        assert result[0]["table"] == "matches"
+        assert result[0]["row_count"] == 42
+        assert result[1]["embedding_columns"] == ["embedding"]
+
+
+# ---------------------------------------------------------------------------
+# SQLServerMatchRepository — get_teams
+# ---------------------------------------------------------------------------
+
+class TestSQLServerGetTeams:
+    def test_get_teams_returns_list_of_dicts(self):
+        repo = SQLServerMatchRepository.__new__(SQLServerMatchRepository)
+        rows = [(1, "Spain", "male", "Spain"), (2, "England", "male", "England")]
+        with _mock_sql_connection(rows) as (conn, _):
+            repo.get_connection = MagicMock(return_value=contextmanager(lambda: (yield conn))())
+            result = repo.get_teams()
+        assert len(result) == 2
+        assert result[0]["name"] == "Spain"
+
+    def test_get_teams_with_match_id_filter(self):
+        repo = SQLServerMatchRepository.__new__(SQLServerMatchRepository)
+        rows = [(1, "Spain", "male", "Spain")]
+        with _mock_sql_connection(rows) as (conn, cursor):
+            repo.get_connection = MagicMock(return_value=contextmanager(lambda: (yield conn))())
+            result = repo.get_teams(match_id=456)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# SQLServerMatchRepository — get_players
+# ---------------------------------------------------------------------------
+
+class TestSQLServerGetPlayers:
+    def test_get_players_returns_list_when_table_exists(self):
+        repo = SQLServerMatchRepository.__new__(SQLServerMatchRepository)
+        player_rows = [(10, "Pedri", 8, "Spain", "Midfielder", "Spain")]
+
+        call_count = [0]
+
+        def make_conn(fetchone_val, fetchall_val):
+            cursor = MagicMock()
+            cursor.fetchone.return_value = fetchone_val
+            cursor.fetchall.return_value = fetchall_val
+            cursor.__enter__ = MagicMock(return_value=cursor)
+            cursor.__exit__ = MagicMock(return_value=False)
+            c = MagicMock()
+            c.cursor.return_value = cursor
+            c.__enter__ = MagicMock(return_value=c)
+            c.__exit__ = MagicMock(return_value=False)
+            return c
+
+        conn1 = make_conn((1,), [])
+        conn2 = make_conn(None, player_rows)
+
+        def get_conn_side_effect():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return contextmanager(lambda: (yield conn1))()
+            return contextmanager(lambda: (yield conn2))()
+
+        repo.get_connection = MagicMock(side_effect=get_conn_side_effect)
+        result = repo.get_players()
+        assert len(result) == 1
+        assert result[0]["player_name"] == "Pedri"
+
+    def test_get_players_returns_empty_when_table_missing(self):
+        repo = SQLServerMatchRepository.__new__(SQLServerMatchRepository)
+        cursor = MagicMock()
+        cursor.fetchone.return_value = None
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        repo.get_connection = MagicMock(return_value=contextmanager(lambda: (yield conn))())
+        result = repo.get_players()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# SQLServerMatchRepository — get_tables_info
+# ---------------------------------------------------------------------------
+
+class TestSQLServerGetTablesInfo:
+    def test_get_tables_info_returns_table_metadata(self):
+        repo = SQLServerMatchRepository.__new__(SQLServerMatchRepository)
+
+        cursor = MagicMock()
+        call_count = [0]
+
+        def fetchall_side_effect():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [("matches",), ("events",)]
+            elif call_count[0] == 2:
+                return [("events", "embedding")]
+            return []
+
+        cursor.fetchall = MagicMock(side_effect=fetchall_side_effect)
+        cursor.fetchone = MagicMock(return_value=(42,))
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        repo.get_connection = MagicMock(return_value=contextmanager(lambda: (yield conn))())
+        result = repo.get_tables_info()
+        assert len(result) == 2
+        assert result[0]["table"] == "matches"
+        assert result[0]["row_count"] == 42
+
+
+# ---------------------------------------------------------------------------
+# EventRepository — get_tables_info (both implementations)
+# ---------------------------------------------------------------------------
+
+class TestEventRepoGetTablesInfo:
+    def test_postgres_event_repo_get_tables_info(self):
+        repo = PostgresEventRepository.__new__(PostgresEventRepository)
+        cursor = MagicMock()
+        cursor.fetchall = MagicMock(side_effect=[
+            [("events",)],
+            [],
+        ])
+        cursor.fetchone = MagicMock(return_value=(10,))
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        repo.get_connection = MagicMock(return_value=contextmanager(lambda: (yield conn))())
+        result = repo.get_tables_info()
+        assert len(result) == 1
+        assert result[0]["table"] == "events"
+
+    def test_sqlserver_event_repo_get_tables_info(self):
+        repo = SQLServerEventRepository.__new__(SQLServerEventRepository)
+        cursor = MagicMock()
+        cursor.fetchall = MagicMock(side_effect=[
+            [("events",)],
+            [],
+        ])
+        cursor.fetchone = MagicMock(return_value=(10,))
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        repo.get_connection = MagicMock(return_value=contextmanager(lambda: (yield conn))())
+        result = repo.get_tables_info()
+        assert len(result) == 1

--- a/openspec/changes/fix-data-explorer-service/.openspec.yaml
+++ b/openspec/changes/fix-data-explorer-service/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-06

--- a/openspec/changes/fix-data-explorer-service/design.md
+++ b/openspec/changes/fix-data-explorer-service/design.md
@@ -1,0 +1,41 @@
+## Approach
+
+Refactor `DataExplorerService` to delegate database access to injected repositories,
+following the existing Repository Pattern. The service keeps its orchestration role
+but loses all raw driver code.
+
+### Strategy
+
+1. **Extend repository interfaces** — add `get_teams()`, `get_players()`, `get_tables_info()` to `MatchRepository` (teams/players relate to matches) or introduce a lightweight `ExplorerRepository` if methods don't fit the existing abstractions.
+2. **Implement in both backends** — `PostgresMatchRepository` and `SQLServerMatchRepository` get the new methods with their respective SQL dialects.
+3. **Refactor service** — inject repositories, remove `_get_connection()`, `_table_exists()`, and all `psycopg2`/`pyodbc` imports.
+4. **Update DI provider** — `get_data_explorer_service()` passes repositories from existing DI.
+5. **Simplify tests** — mock at repository interface level instead of driver level.
+
+### Decision: Where to put the new methods
+
+**Option A:** Add to `MatchRepository` — teams/players are match-related data.
+**Option B:** New `ExplorerRepository` — these are metadata/exploration queries, different from domain queries.
+
+**Choice: Option A** — the queries are about match-related entities (teams, players). Adding a new repository for 3 methods would be over-abstraction. `get_tables_info()` is a DB metadata query that fits in `BaseRepository`.
+
+## File changes
+
+| File | Change |
+|------|--------|
+| `backend/app/repositories/base.py` | (modified) Add `get_teams()`, `get_players()` to `MatchRepository`; add `get_tables_info()` to `BaseRepository` |
+| `backend/app/repositories/postgres.py` | (modified) Implement new methods in `PostgresMatchRepository` |
+| `backend/app/repositories/sqlserver.py` | (modified) Implement new methods in `SQLServerMatchRepository` |
+| `backend/app/services/data_explorer_service.py` | (modified) Remove raw connections, delegate to injected repos |
+| `backend/app/core/dependencies.py` | (modified) Update `get_data_explorer_service()` to pass repos |
+| `backend/tests/unit/test_dependencies_and_explorer_service.py` | (modified) Simplify mocks to repository level |
+
+## Rollback strategy
+
+All changes are internal refactoring — the API contract is unchanged.
+Rollback: revert the commit. No data migration, no env var changes, no breaking API changes.
+
+## Risks
+
+- **[Risk]** Existing tests mock at driver level → **Mitigation:** rewrite tests to mock repository interfaces, which is simpler and catches more real bugs
+- **[Risk]** SQL queries may behave differently when moved to repository → **Mitigation:** preserve exact SQL, just move it; API tests verify end-to-end behavior

--- a/openspec/changes/fix-data-explorer-service/proposal.md
+++ b/openspec/changes/fix-data-explorer-service/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+`DataExplorerService` bypasses the Repository Pattern by managing raw `psycopg2`/`pyodbc`
+connections directly (`_get_connection()` at line 22). This violates the architecture rule
+that services must delegate all database access to injected repositories. It duplicates
+SQL dialect branching already solved in the repository layer, makes unit tests harder
+(must mock drivers instead of interfaces), and couples the service to specific driver versions.
+The data spec explicitly flags this as a deviation to be reviewed.
+
+## What Changes
+
+- Remove `_get_connection()` and all raw `psycopg2`/`pyodbc` usage from `DataExplorerService`
+- Add repository methods for the three queries DataExplorerService currently handles:
+  `get_teams()`, `get_players()`, `get_tables_info()`
+- Refactor `DataExplorerService` to accept injected repositories and delegate queries
+- Simplify unit tests from driver-level mocking to repository interface mocking
+- Fully backwards-compatible: API contract (routes, request/response) unchanged
+
+## Capabilities
+
+### New Capabilities
+
+(none — this is a refactoring of existing behavior)
+
+### Modified Capabilities
+
+- `data`: Repository interfaces (`MatchRepository`, `EventRepository`) gain new query methods for teams, players, and table metadata
+
+## Impact
+
+- **Affected layers:** Service (`data_explorer_service.py`), Repository (`base.py`, `postgres.py`, `sqlserver.py`), DI (`dependencies.py`)
+- **Affected files:** 6 production files, 2 test files
+- **API contract:** No change — routes, request params, and response shapes remain identical
+- **Test impact:** Unit tests simplified (mock repos instead of drivers); API tests unchanged
+- **Backwards compatibility:** Fully compatible — external behavior identical
+- **Breaking:** None

--- a/openspec/changes/fix-data-explorer-service/specs/data/spec.md
+++ b/openspec/changes/fix-data-explorer-service/specs/data/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Repository interfaces for exploration queries
+
+`MatchRepository` SHALL provide the following additional methods:
+
+- `get_teams(match_id: Optional[int], limit: int) -> List[Dict[str, Any]]`
+  Returns team metadata (team_id, name, gender, country, manager).
+- `get_players(match_id: Optional[int], limit: int) -> List[Dict[str, Any]]`
+  Returns player roster data (player_id, name, jersey_number, country, position, team_name).
+
+`BaseRepository` SHALL provide:
+
+- `get_tables_info() -> List[Dict[str, Any]]`
+  Returns table metadata (name, row_count, columns, has_embedding).
+
+`DataExplorerService` MUST NOT import or use `psycopg2` or `pyodbc` directly.
+All database access MUST go through injected repository instances.
+
+### Requirement: Backwards compatibility
+
+The API contract for `/api/v1/teams`, `/api/v1/players`, and `/api/v1/tables-info`
+MUST remain unchanged. Response shapes, status codes, and query parameters SHALL
+be identical before and after the refactoring.
+
+#### Scenario: Teams query via repository
+- **GIVEN** a `DataExplorerService` with an injected `MatchRepository`
+- **WHEN** `get_teams(source="postgres")` is called
+- **THEN** the service SHALL delegate to `match_repo.get_teams()` without creating any raw connection
+
+#### Scenario: No raw driver imports in service
+- **GIVEN** the refactored `DataExplorerService`
+- **WHEN** inspecting its imports
+- **THEN** neither `psycopg2` nor `pyodbc` SHALL appear
+
+### REMOVED Deviation
+
+The known deviation "DataExplorerService bypasses the Repository Pattern" SHALL be removed
+from `openspec/specs/data/spec.md` after this change is implemented.

--- a/openspec/changes/fix-data-explorer-service/tasks.md
+++ b/openspec/changes/fix-data-explorer-service/tasks.md
@@ -1,0 +1,26 @@
+## 1. Repository layer
+
+- [x] 1.1 Add abstract methods `get_teams(match_id, limit)` and `get_players(match_id, limit)` to `MatchRepository` in `base.py`
+- [x] 1.2 Add abstract method `get_tables_info()` to `BaseRepository` in `base.py`
+- [x] 1.3 Implement `get_teams()` and `get_players()` in `PostgresMatchRepository` (move SQL from service)
+- [x] 1.4 Implement `get_teams()` and `get_players()` in `SQLServerMatchRepository` (move SQL from service)
+- [x] 1.5 Implement `get_tables_info()` in both Postgres and SQL Server base repositories
+
+## 2. Service layer
+
+- [x] 2.1 Refactor `DataExplorerService.__init__()` to accept `MatchRepository` instead of `Settings`
+- [x] 2.2 Refactor `get_teams()`, `get_players()`, `get_tables_info()` to delegate to repository
+- [x] 2.3 Remove `_get_connection()`, `_table_exists()`, and all `psycopg2`/`pyodbc` imports
+
+## 3. DI layer
+
+- [x] 3.1 Update `get_data_explorer_service()` in `dependencies.py` to pass `MatchRepository`
+
+## 4. Tests (TDD — write before implementation)
+
+- [x] 4.1 Write unit test: `test_get_teams_delegates_to_repository` — verify service calls `match_repo.get_teams()`
+- [x] 4.2 Write unit test: `test_get_players_delegates_to_repository` — verify service calls `match_repo.get_players()`
+- [x] 4.3 Write unit test: `test_get_tables_info_delegates_to_repository` — verify service calls `repo.get_tables_info()`
+- [x] 4.4 Write unit test: `test_service_has_no_psycopg2_import` — verify no raw driver imports
+- [x] 4.5 Update existing API tests if any mock patching paths changed
+- [x] 4.6 Run full test suite and verify 80%+ coverage maintained


### PR DESCRIPTION
## Summary
- Refactor `DataExplorerService` to delegate database access to injected repositories instead of raw `psycopg2`/`pyodbc` connections
- Add `get_teams()`, `get_players()` to `MatchRepository` and `get_tables_info()` to `BaseRepository`
- Implement in both PostgreSQL and SQL Server repositories
- Remove `_get_connection()`, `_table_exists()`, and all driver imports from service

## Files changed
| File | Change |
|------|--------|
| `repositories/base.py` | Add abstract methods for teams, players, tables_info |
| `repositories/postgres.py` | Implement new methods (SQL moved from service) |
| `repositories/sqlserver.py` | Same implementation for SQL Server |
| `services/data_explorer_service.py` | Refactored — delegates to repos, no driver imports |
| `core/dependencies.py` | Updated DI provider to pass MatchRepository |
| `tests/unit/test_dependencies_and_explorer_service.py` | Rewritten with repo-level mocking |

## Test plan
- [x] 445 tests pass
- [x] Lint clean (ruff check)
- [x] No psycopg2/pyodbc imports in service
- [x] API contract unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code) — parallel worktree