### PR TITLE
fix(api): replace direct repo instantiation with Depends() in health and capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Replace direct `PostgresEventRepository()` / `SQLServerEventRepository()` instantiation in `health.py` and `capabilities.py` with FastAPI `Depends()` injection
+- Add `get_postgres_event_repository` and `get_sqlserver_event_repository` DI providers in `dependencies.py`
+
 ### Security
 - Replace `allow_origins=["*"]` with configurable `CORS_ORIGINS` env var in CORS middleware
 - Add `cors_origins` setting to `config/settings.py` with safe localhost defaults

--- a/backend/app/api/v1/capabilities.py
+++ b/backend/app/api/v1/capabilities.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, Depends, Query, status
 from pydantic import BaseModel
 
 from app.core.capabilities import (
@@ -10,8 +10,8 @@ from app.core.capabilities import (
     get_source_capabilities,
     normalize_source,
 )
-from app.repositories.postgres import PostgresEventRepository
-from app.repositories.sqlserver import SQLServerEventRepository
+from app.core.dependencies import get_postgres_event_repository, get_sqlserver_event_repository
+from app.repositories.base import EventRepository
 
 router = APIRouter()
 
@@ -71,12 +71,19 @@ async def get_capabilities() -> CapabilitiesResponse:
     description="Check connectivity for postgres and sqlserver repositories.",
 )
 async def get_sources_status(
+    postgres_repo: EventRepository = Depends(get_postgres_event_repository),
+    sqlserver_repo: EventRepository = Depends(get_sqlserver_event_repository),
     source: str | None = Query(
         default=None,
         description="Optional source filter: postgres or sqlserver",
     ),
 ) -> SourceStatusResponse:
     """Check repository-level connectivity per source."""
+    repos = {
+        "postgres": postgres_repo,
+        "sqlserver": sqlserver_repo,
+    }
+
     requested_sources: list[str]
     if source:
         requested_sources = [normalize_source(source)]
@@ -87,10 +94,7 @@ async def get_sources_status(
 
     items: list[SourceStatusItem] = []
     for src in requested_sources:
-        if src == "postgres":
-            connected = PostgresEventRepository().test_connection()
-        else:
-            connected = SQLServerEventRepository().test_connection()
+        connected = repos[src].test_connection()
         items.append(SourceStatusItem(source=src, connected=connected))
 
     return SourceStatusResponse(timestamp=datetime.utcnow(), sources=items)

--- a/backend/app/api/v1/capabilities.py
+++ b/backend/app/api/v1/capabilities.py
@@ -10,7 +10,10 @@ from app.core.capabilities import (
     get_source_capabilities,
     normalize_source,
 )
-from app.core.dependencies import get_postgres_event_repository, get_sqlserver_event_repository
+from app.core.dependencies import (
+    get_postgres_event_repository,
+    get_sqlserver_event_repository,
+)
 from app.repositories.base import EventRepository
 
 router = APIRouter()

--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -11,7 +11,10 @@ from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel
 
 from app.core.config import Settings, get_settings
-from app.core.dependencies import get_postgres_event_repository, get_sqlserver_event_repository
+from app.core.dependencies import (
+    get_postgres_event_repository,
+    get_sqlserver_event_repository,
+)
 from app.repositories.base import EventRepository
 
 router = APIRouter()

--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -11,8 +11,8 @@ from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel
 
 from app.core.config import Settings, get_settings
-from app.repositories.postgres import PostgresEventRepository
-from app.repositories.sqlserver import SQLServerEventRepository
+from app.core.dependencies import get_postgres_event_repository, get_sqlserver_event_repository
+from app.repositories.base import EventRepository
 
 router = APIRouter()
 
@@ -74,6 +74,8 @@ async def health_check(settings: Settings = Depends(get_settings)) -> HealthResp
     description="Check if the service is ready to accept requests",
 )
 async def readiness_check(
+    postgres_repo: EventRepository = Depends(get_postgres_event_repository),
+    sqlserver_repo: EventRepository = Depends(get_sqlserver_event_repository),
     settings: Settings = Depends(get_settings),
 ) -> ReadinessResponse:
     """
@@ -83,13 +85,15 @@ async def readiness_check(
     Returns 200 OK only if the service is ready to handle requests.
 
     Args:
+        postgres_repo: PostgreSQL event repository (injected)
+        sqlserver_repo: SQL Server event repository (injected)
         settings: Application settings (injected)
 
     Returns:
         ReadinessResponse: Service readiness information
     """
-    postgres_ok = PostgresEventRepository().test_connection()
-    sqlserver_ok = SQLServerEventRepository().test_connection()
+    postgres_ok = postgres_repo.test_connection()
+    sqlserver_ok = sqlserver_repo.test_connection()
 
     checks = {
         "api": True,

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -43,6 +43,16 @@ MatchRepo = Annotated[MatchRepository, Depends(get_match_repository)]
 EventRepo = Annotated[EventRepository, Depends(get_event_repository)]
 
 
+def get_postgres_event_repository() -> EventRepository:
+    """Dependency provider for PostgreSQL EventRepository (health/connectivity checks)."""
+    return get_event_repository(source="postgres")
+
+
+def get_sqlserver_event_repository() -> EventRepository:
+    """Dependency provider for SQL Server EventRepository (health/connectivity checks)."""
+    return get_event_repository(source="sqlserver")
+
+
 def get_statsbomb_service() -> StatsBombService:
     """Dependency provider for StatsBombService."""
     return StatsBombService()

--- a/backend/tests/api/test_capabilities.py
+++ b/backend/tests/api/test_capabilities.py
@@ -5,24 +5,42 @@ GET /api/v1/capabilities
 GET /api/v1/sources/status
 """
 
-from unittest.mock import patch
+import ast
+import inspect
+from unittest.mock import MagicMock
+
 import pytest
 from fastapi.testclient import TestClient
 
+from app.repositories.base import EventRepository
 from tests.conftest import make_mock_match_repo, make_mock_event_repo, make_mock_openai_adapter
 
 
 @pytest.fixture
 def client():
     from app.main import app
-    from app.core.dependencies import get_match_repository, get_event_repository
+    from app.core.dependencies import (
+        get_match_repository,
+        get_event_repository,
+        get_postgres_event_repository,
+        get_sqlserver_event_repository,
+    )
     from app.adapters.openai_client import get_openai_adapter
+
+    mock_pg_repo = MagicMock(spec=EventRepository)
+    mock_pg_repo.test_connection.return_value = True
+    mock_sql_repo = MagicMock(spec=EventRepository)
+    mock_sql_repo.test_connection.return_value = True
 
     app.dependency_overrides[get_match_repository] = lambda source="postgres": make_mock_match_repo()
     app.dependency_overrides[get_event_repository] = lambda source="postgres": make_mock_event_repo()
+    app.dependency_overrides[get_postgres_event_repository] = lambda: mock_pg_repo
+    app.dependency_overrides[get_sqlserver_event_repository] = lambda: mock_sql_repo
     app.dependency_overrides[get_openai_adapter] = lambda: make_mock_openai_adapter()
 
     with TestClient(app, raise_server_exceptions=False) as c:
+        c._mock_pg_repo = mock_pg_repo  # type: ignore[attr-defined]
+        c._mock_sql_repo = mock_sql_repo  # type: ignore[attr-defined]
         yield c
 
     app.dependency_overrides.clear()
@@ -80,56 +98,54 @@ class TestCapabilitiesEndpoint:
 # ===========================================================================
 
 class TestSourcesStatusEndpoint:
+    def test_sources_status_uses_injected_repos(self, client):
+        """Verify sources/status endpoint uses DI-injected repos (not direct instantiation)."""
+        response = client.get("/api/v1/sources/status")
+        assert response.status_code == 200
+        # The injected mocks should have been called
+        client._mock_pg_repo.test_connection.assert_called_once()
+        client._mock_sql_repo.test_connection.assert_called_once()
+
     def test_returns_200(self, client):
-        with patch("app.api.v1.capabilities.PostgresEventRepository") as pg, \
-             patch("app.api.v1.capabilities.SQLServerEventRepository") as sql:
-            pg.return_value.test_connection.return_value = True
-            sql.return_value.test_connection.return_value = True
-            assert client.get("/api/v1/sources/status").status_code == 200
+        client._mock_pg_repo.test_connection.return_value = True
+        client._mock_sql_repo.test_connection.return_value = True
+        assert client.get("/api/v1/sources/status").status_code == 200
 
     def test_returns_both_sources_by_default(self, client):
-        with patch("app.api.v1.capabilities.PostgresEventRepository") as pg, \
-             patch("app.api.v1.capabilities.SQLServerEventRepository") as sql:
-            pg.return_value.test_connection.return_value = True
-            sql.return_value.test_connection.return_value = True
-            data = client.get("/api/v1/sources/status").json()
+        client._mock_pg_repo.test_connection.return_value = True
+        client._mock_sql_repo.test_connection.return_value = True
+        data = client.get("/api/v1/sources/status").json()
 
         sources = {s["source"] for s in data["sources"]}
         assert "postgres" in sources
         assert "sqlserver" in sources
 
     def test_connected_true_when_db_up(self, client):
-        with patch("app.api.v1.capabilities.PostgresEventRepository") as pg, \
-             patch("app.api.v1.capabilities.SQLServerEventRepository") as sql:
-            pg.return_value.test_connection.return_value = True
-            sql.return_value.test_connection.return_value = True
-            data = client.get("/api/v1/sources/status").json()
+        client._mock_pg_repo.test_connection.return_value = True
+        client._mock_sql_repo.test_connection.return_value = True
+        data = client.get("/api/v1/sources/status").json()
 
         pg_status = next(s for s in data["sources"] if s["source"] == "postgres")
         assert pg_status["connected"] is True
 
     def test_connected_false_when_db_down(self, client):
-        with patch("app.api.v1.capabilities.PostgresEventRepository") as pg, \
-             patch("app.api.v1.capabilities.SQLServerEventRepository") as sql:
-            pg.return_value.test_connection.return_value = False
-            sql.return_value.test_connection.return_value = False
-            data = client.get("/api/v1/sources/status").json()
+        client._mock_pg_repo.test_connection.return_value = False
+        client._mock_sql_repo.test_connection.return_value = False
+        data = client.get("/api/v1/sources/status").json()
 
         for item in data["sources"]:
             assert item["connected"] is False
 
     def test_filter_by_postgres(self, client):
-        with patch("app.api.v1.capabilities.PostgresEventRepository") as pg:
-            pg.return_value.test_connection.return_value = True
-            data = client.get("/api/v1/sources/status?source=postgres").json()
+        client._mock_pg_repo.test_connection.return_value = True
+        data = client.get("/api/v1/sources/status?source=postgres").json()
 
         assert len(data["sources"]) == 1
         assert data["sources"][0]["source"] == "postgres"
 
     def test_filter_by_sqlserver(self, client):
-        with patch("app.api.v1.capabilities.SQLServerEventRepository") as sql:
-            sql.return_value.test_connection.return_value = True
-            data = client.get("/api/v1/sources/status?source=sqlserver").json()
+        client._mock_sql_repo.test_connection.return_value = True
+        data = client.get("/api/v1/sources/status?source=sqlserver").json()
 
         assert len(data["sources"]) == 1
         assert data["sources"][0]["source"] == "sqlserver"
@@ -139,10 +155,23 @@ class TestSourcesStatusEndpoint:
         assert response.status_code in (400, 500)
 
     def test_response_has_timestamp(self, client):
-        with patch("app.api.v1.capabilities.PostgresEventRepository") as pg, \
-             patch("app.api.v1.capabilities.SQLServerEventRepository") as sql:
-            pg.return_value.test_connection.return_value = True
-            sql.return_value.test_connection.return_value = True
-            data = client.get("/api/v1/sources/status").json()
+        client._mock_pg_repo.test_connection.return_value = True
+        client._mock_sql_repo.test_connection.return_value = True
+        data = client.get("/api/v1/sources/status").json()
 
         assert "timestamp" in data
+
+
+class TestNoDirectRepoImportsInCapabilities:
+    def test_no_direct_repo_imports_in_capabilities_handler(self):
+        """Verify capabilities.py does not import concrete repository classes."""
+        import app.api.v1.capabilities as caps_module
+        source = inspect.getsource(caps_module)
+        tree = ast.parse(source)
+        concrete_repos = {"PostgresEventRepository", "SQLServerEventRepository"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    assert alias.name not in concrete_repos, (
+                        f"capabilities.py must not import {alias.name} directly"
+                    )

--- a/backend/tests/api/test_health.py
+++ b/backend/tests/api/test_health.py
@@ -4,23 +4,42 @@ API tests for health endpoints.
 /api/v1/health, /api/v1/health/live, /api/v1/health/ready
 """
 
-from unittest.mock import patch, MagicMock
+import ast
+import inspect
+from unittest.mock import MagicMock
+
 import pytest
 from fastapi.testclient import TestClient
+
+from app.repositories.base import EventRepository
+from tests.conftest import make_mock_match_repo, make_mock_event_repo, make_mock_openai_adapter
 
 
 @pytest.fixture
 def client():
     from app.main import app
-    from app.core.dependencies import get_match_repository, get_event_repository
+    from app.core.dependencies import (
+        get_match_repository,
+        get_event_repository,
+        get_postgres_event_repository,
+        get_sqlserver_event_repository,
+    )
     from app.adapters.openai_client import get_openai_adapter
-    from tests.conftest import make_mock_match_repo, make_mock_event_repo, make_mock_openai_adapter
+
+    mock_pg_repo = MagicMock(spec=EventRepository)
+    mock_pg_repo.test_connection.return_value = True
+    mock_sql_repo = MagicMock(spec=EventRepository)
+    mock_sql_repo.test_connection.return_value = True
 
     app.dependency_overrides[get_match_repository] = lambda source="postgres": make_mock_match_repo()
     app.dependency_overrides[get_event_repository] = lambda source="postgres": make_mock_event_repo()
+    app.dependency_overrides[get_postgres_event_repository] = lambda: mock_pg_repo
+    app.dependency_overrides[get_sqlserver_event_repository] = lambda: mock_sql_repo
     app.dependency_overrides[get_openai_adapter] = lambda: make_mock_openai_adapter()
 
     with TestClient(app, raise_server_exceptions=False) as c:
+        c._mock_pg_repo = mock_pg_repo  # type: ignore[attr-defined]
+        c._mock_sql_repo = mock_sql_repo  # type: ignore[attr-defined]
         yield c
 
     app.dependency_overrides.clear()
@@ -63,13 +82,19 @@ class TestHealthEndpoint:
 
 
 class TestReadinessEndpoint:
-    def test_both_dbs_up_returns_ready(self, client):
-        with patch("app.api.v1.health.PostgresEventRepository") as mock_pg, \
-             patch("app.api.v1.health.SQLServerEventRepository") as mock_sql:
-            mock_pg.return_value.test_connection.return_value = True
-            mock_sql.return_value.test_connection.return_value = True
+    def test_readiness_check_uses_injected_repos(self, client):
+        """Verify readiness endpoint uses DI-injected repos (not direct instantiation)."""
+        response = client.get("/api/v1/health/ready")
+        assert response.status_code == 200
+        # The injected mocks should have been called
+        client._mock_pg_repo.test_connection.assert_called_once()
+        client._mock_sql_repo.test_connection.assert_called_once()
 
-            response = client.get("/api/v1/health/ready")
+    def test_both_dbs_up_returns_ready(self, client):
+        client._mock_pg_repo.test_connection.return_value = True
+        client._mock_sql_repo.test_connection.return_value = True
+
+        response = client.get("/api/v1/health/ready")
 
         assert response.status_code == 200
         data = response.json()
@@ -78,12 +103,10 @@ class TestReadinessEndpoint:
         assert data["checks"]["sqlserver"] is True
 
     def test_postgres_down_returns_not_ready(self, client):
-        with patch("app.api.v1.health.PostgresEventRepository") as mock_pg, \
-             patch("app.api.v1.health.SQLServerEventRepository") as mock_sql:
-            mock_pg.return_value.test_connection.return_value = False
-            mock_sql.return_value.test_connection.return_value = True
+        client._mock_pg_repo.test_connection.return_value = False
+        client._mock_sql_repo.test_connection.return_value = True
 
-            response = client.get("/api/v1/health/ready")
+        response = client.get("/api/v1/health/ready")
 
         assert response.status_code == 200
         data = response.json()
@@ -91,27 +114,38 @@ class TestReadinessEndpoint:
         assert data["checks"]["postgres"] is False
 
     def test_sqlserver_down_returns_not_ready(self, client):
-        with patch("app.api.v1.health.PostgresEventRepository") as mock_pg, \
-             patch("app.api.v1.health.SQLServerEventRepository") as mock_sql:
-            mock_pg.return_value.test_connection.return_value = True
-            mock_sql.return_value.test_connection.return_value = False
+        client._mock_pg_repo.test_connection.return_value = True
+        client._mock_sql_repo.test_connection.return_value = False
 
-            response = client.get("/api/v1/health/ready")
+        response = client.get("/api/v1/health/ready")
 
         data = response.json()
         assert data["ready"] is False
         assert data["checks"]["sqlserver"] is False
 
     def test_both_dbs_down_returns_not_ready(self, client):
-        with patch("app.api.v1.health.PostgresEventRepository") as mock_pg, \
-             patch("app.api.v1.health.SQLServerEventRepository") as mock_sql:
-            mock_pg.return_value.test_connection.return_value = False
-            mock_sql.return_value.test_connection.return_value = False
+        client._mock_pg_repo.test_connection.return_value = False
+        client._mock_sql_repo.test_connection.return_value = False
 
-            response = client.get("/api/v1/health/ready")
+        response = client.get("/api/v1/health/ready")
 
         data = response.json()
         assert data["ready"] is False
+
+
+class TestNoDirectRepoImportsInHealth:
+    def test_no_direct_repo_imports_in_health_handler(self):
+        """Verify health.py does not import concrete repository classes."""
+        import app.api.v1.health as health_module
+        source = inspect.getsource(health_module)
+        tree = ast.parse(source)
+        concrete_repos = {"PostgresEventRepository", "SQLServerEventRepository"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    assert alias.name not in concrete_repos, (
+                        f"health.py must not import {alias.name} directly"
+                    )
 
 
 class TestRootEndpoint:

--- a/openspec/changes/fix-dependency-injection/design.md
+++ b/openspec/changes/fix-dependency-injection/design.md
@@ -1,0 +1,43 @@
+## Approach
+
+Replace direct repository instantiation with FastAPI `Depends()` injection in the two
+remaining handlers. The existing DI providers (`get_match_repository`, `get_event_repository`)
+already support a `source` parameter — reuse them.
+
+### Strategy
+
+1. **`health.py` readiness check** — inject both Postgres and SQL Server event repositories
+   via `Depends()`. The `readiness_check()` handler calls `.test_connection()` on each.
+2. **`capabilities.py` source status** — same pattern: inject repositories, call `.test_connection()`.
+3. **No new DI providers needed** — `get_event_repository(source)` already exists and returns
+   the correct implementation based on source.
+
+### Decision: How to inject both sources
+
+The existing `get_event_repository(source="postgres")` returns one implementation at a time.
+For health/capabilities we need both. Options:
+
+**Option A:** Two separate `Depends()` calls with different source defaults.
+**Option B:** A new `get_connectivity_checker()` provider that returns both.
+
+**Choice: Option A** — simpler, no new abstractions for 2 call sites. Each handler declares
+two parameters with `Depends(get_event_repository)` using different source values.
+
+## File changes
+
+| File | Change |
+|------|--------|
+| `backend/app/api/v1/health.py` | (modified) Replace direct `PostgresEventRepository()` / `SQLServerEventRepository()` with injected repos |
+| `backend/app/api/v1/capabilities.py` | (modified) Same replacement pattern |
+| `backend/tests/api/test_health.py` | (modified) Update mocks to use dependency overrides |
+| `backend/tests/api/test_capabilities.py` | (modified) Update mocks to use dependency overrides |
+
+## Rollback strategy
+
+Revert the commit. No data migration, no env var changes, no API contract changes.
+
+## Risks
+
+- **[Risk]** Health check currently works without DI container being fully initialized →
+  **Mitigation:** `test_connection()` is a simple method that doesn't require other dependencies.
+  The repositories are lightweight to construct via `Depends()`.

--- a/openspec/changes/fix-dependency-injection/proposal.md
+++ b/openspec/changes/fix-dependency-injection/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Two API handlers (`health.py` and `capabilities.py`) instantiate repository implementations
+directly (`PostgresEventRepository()`, `SQLServerEventRepository()`) instead of using
+FastAPI `Depends()`. This violates the DI architecture rule, makes those handlers untestable
+without a live database, and creates tight coupling to concrete implementations.
+
+All other handlers already use `Depends()` correctly — these two are the last holdouts.
+
+## What Changes
+
+- Replace direct `PostgresEventRepository()` / `SQLServerEventRepository()` instantiation
+  in `health.py` readiness check with injected repositories
+- Replace direct instantiation in `capabilities.py` source status check with injected repositories
+- Add a DI provider for health/connectivity checks if needed
+- Update tests to use dependency overrides instead of mocking constructors
+
+## Capabilities
+
+### New Capabilities
+
+(none — this is a refactoring of existing behavior)
+
+### Modified Capabilities
+
+- `api`: Health and capabilities endpoints use injected repositories instead of direct instantiation
+
+## Impact
+
+- **Affected layers:** API (`health.py`, `capabilities.py`), DI (`dependencies.py`)
+- **Affected files:** 2 handler files, 1 DI file, 2 test files
+- **API contract:** No change — response shapes and status codes remain identical
+- **Test impact:** Health/capabilities tests can use dependency overrides (no live DB needed)
+- **Backwards compatibility:** Fully compatible
+- **Breaking:** None

--- a/openspec/changes/fix-dependency-injection/specs/api/spec.md
+++ b/openspec/changes/fix-dependency-injection/specs/api/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Health and capabilities handlers use DI
+
+The `readiness_check()` handler in `health.py` MUST receive repository instances via
+FastAPI `Depends()` injection. It MUST NOT instantiate `PostgresEventRepository` or
+`SQLServerEventRepository` directly.
+
+The `get_sources_status()` handler in `capabilities.py` MUST follow the same pattern.
+
+#### Scenario: Readiness check uses injected repositories
+- **GIVEN** a FastAPI app with DI overrides for repositories
+- **WHEN** `GET /api/v1/health/ready` is called
+- **THEN** the handler SHALL use the injected repository's `test_connection()` method
+- **AND** SHALL NOT import or instantiate concrete repository classes
+
+#### Scenario: Capabilities source status uses injected repositories
+- **GIVEN** a FastAPI app with DI overrides for repositories
+- **WHEN** `GET /api/v1/capabilities/sources` is called
+- **THEN** the handler SHALL use the injected repository's `test_connection()` method
+
+### REMOVED Deviation
+
+Any known deviation about direct repository instantiation in health/capabilities handlers
+SHALL be removed after this change.

--- a/openspec/changes/fix-dependency-injection/tasks.md
+++ b/openspec/changes/fix-dependency-injection/tasks.md
@@ -1,0 +1,13 @@
+## 1. API layer
+
+- [x] 1.1 Refactor `health.py:readiness_check()` to accept repositories via `Depends()` instead of instantiating `PostgresEventRepository()` / `SQLServerEventRepository()`
+- [x] 1.2 Refactor `capabilities.py:get_sources_status()` with the same pattern
+- [x] 1.3 Remove direct imports of concrete repository classes from both handlers
+
+## 2. Tests (TDD — write before implementation)
+
+- [x] 2.1 Write unit test: `test_readiness_check_uses_injected_repos` — verify handler uses DI, not direct instantiation
+- [x] 2.2 Write unit test: `test_sources_status_uses_injected_repos` — same for capabilities
+- [x] 2.3 Update existing health/capabilities API tests to use `dependency_overrides` if they mock constructors
+- [x] 2.4 Write unit test: `test_no_direct_repo_imports_in_handlers` — verify no concrete repo imports in health.py and capabilities.py
+- [x] 2.5 Run full test suite and verify 80%+ coverage maintained


### PR DESCRIPTION
## Summary
- Replace direct `PostgresEventRepository()` / `SQLServerEventRepository()` instantiation in `health.py` and `capabilities.py` with FastAPI `Depends()` injection
- Add `get_postgres_event_repository()` and `get_sqlserver_event_repository()` DI providers
- Update tests to use `dependency_overrides` instead of constructor patching

## Files changed
| File | Change |
|------|--------|
| `api/v1/health.py` | Injected repos via Depends(), removed concrete imports |
| `api/v1/capabilities.py` | Same pattern |
| `core/dependencies.py` | Added 2 new DI providers |
| `tests/api/test_health.py` | Replaced patch() with dependency_overrides |
| `tests/api/test_capabilities.py` | Same pattern |

## Test plan
- [x] 443 tests pass
- [x] Lint clean (ruff check)
- [x] No concrete repo imports in handlers
- [x] API contract unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code) — parallel worktree