### PR TITLE
chore(docs): clean up README, PROJECT_STATUS, .gitignore for onboarding

### DIFF
--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -142,11 +142,37 @@ Cada worktree es un directorio aislado con su propia rama, vinculado al mismo re
 
 ## Tags y releases
 
-- Al mergear `develop` → `main`, crear tag: `vX.Y.Z`.
-- Seguir [Semantic Versioning](https://semver.org/):
-  - **MAJOR:** cambios breaking en API pública.
-  - **MINOR:** nueva funcionalidad backwards-compatible.
-  - **PATCH:** correcciones de bugs.
+### Semantic Versioning
+
+Seguir [Semantic Versioning](https://semver.org/): `vMAJOR.MINOR.PATCH`
+
+| Tipo | Cuándo | Ejemplo |
+|------|--------|---------|
+| **MAJOR** | Cambios breaking en API pública (endpoints eliminados, contratos rotos) | v4.0.0 → v5.0.0 |
+| **MINOR** | Nueva funcionalidad backwards-compatible (features, mejoras) | v4.0.0 → v4.1.0 |
+| **PATCH** | Correcciones de bugs sin cambio de API | v4.1.0 → v4.1.1 |
+
+### Proceso de release
+
+1. Verificar que `develop` está limpio: CI green, todos los changes archivados.
+2. Crear PR `develop → main` con título `release: vX.Y.Z`.
+3. En el PR body, copiar la sección `[Unreleased]` del CHANGELOG como release notes.
+4. Mergear el PR (no squash — preservar historial).
+5. Crear tag en `main`: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+6. Actualizar CHANGELOG: renombrar `[Unreleased]` a `[X.Y.Z] - YYYY-MM-DD` y crear nueva sección `[Unreleased]` vacía.
+
+### Cuándo hacer release
+
+- Después de completar un batch de OpenSpec changes (ej: sesión de deuda técnica).
+- Cuando hay un feature significativo listo para producción.
+- Mínimo: cuando `[Unreleased]` acumula más de 5-6 entries.
+- No hay cadencia fija — se hace cuando el conjunto de cambios tiene sentido como unidad.
+
+### Versionado en archivos
+
+- `backend/app/main.py` — campo `version` en FastAPI app.
+- `CHANGELOG.md` — sección `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD`.
+- `README.md` / `PROJECT_STATUS.md` — actualizar si mencionan versión.
 
 ## Conversation log
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,33 @@
+# Environment
 .env
 .env.docker
+.env.local
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+dist/
+build/
+.mypy_cache/
+
+# Testing
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+pytest.out
+
+# Node
+node_modules/
+
+# IDE
+.DS_Store
+*.swp
+*~
+
+# Data (StatsBomb downloads)
 /data/events/
 /data/lineups/
 /data/matches/
@@ -10,19 +38,9 @@
 /backend/data/matches/
 /app/data/scripts_summary/Answers/
 
-*.pyc
-.pytest_cache/
-.coverage
-htmlcov/
-pytest.out
-~
+# Database
 rag_challenge.db
 rag_challenge.db-journal
-04_create_openai_stored_procedures_api_key_included.sql
-dotnetMalaga/Spain Insane Reactions to Oyarzabal 2-1 Goal vs England (EURO Final).mp4
 
-# pytest coverage
-.coverage
-.coverage.*
-htmlcov/
-.pytest_cache/
+# Secrets (never commit)
+04_create_openai_stored_procedures_api_key_included.sql

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Rename ~50 test functions across 15 test files to follow `test_<method>_<scenario>_<expected>` naming convention
 
 ### Added
+- `docs/getting-started.md` — new contributor guide (setup, OpenSpec workflow, where to find things)
 - `frontend/webapp/.env.example` with `VITE_API_BASE_URL` and `VITE_BACKEND_ORIGIN`
 - `.pre-commit-config.yaml` with ruff lint + format hooks for backend
 - Token budget guard in RAG pipeline: counts tokens before LLM call using `tiktoken` and truncates lowest-ranked search results if context exceeds `max_input_tokens`
@@ -27,7 +28,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replace `allow_origins=["*"]` with configurable `CORS_ORIGINS` env var in CORS middleware
 - Add `cors_origins` setting to `config/settings.py` with safe localhost defaults
 
-### Added
+### Governance
 - `AGENTS.md` — single source of truth for all project conventions and agent rules
 - `CLAUDE.md` — Claude Code entry point with project overview, commands, and governance chain
 - `openspec/` — OpenSpec v1.2.0 governance: config, 4 system specs (api, rag, data, infra), 1 archived change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ Read and follow ALL rules in `AGENTS.md` before starting any work.
 That file is the single source of truth for project conventions,
 architecture rules, testing requirements, and workflow.
 
+New to the project? Start with `docs/getting-started.md` — setup, workflow, and where to find things.
+
 Read also these instruction files for specific rules:
 
 - `.github/instructions/git-workflow.instructions.md` — Branch naming, commits, CHANGELOG

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,130 +1,49 @@
-# Project Status Report — RAG-Challenge
+# Project Status — RAG-Challenge
 
 **Last Updated:** 2026-04-06
 **Branch:** `develop`
-**Current Version:** v4.0.0-dev — OpenSpec governance + DI refactor
 **Governance:** [OpenSpec](https://github.com/Fission-AI/OpenSpec) (spec-driven development)
 
 ---
 
-## Executive Summary
+## Summary
 
-### Overall Progress
+| Area | Status |
+|------|--------|
+| Backend (FastAPI) | Complete — layered architecture, DI via Depends(), 470+ tests, 82% coverage |
+| Frontend (React TS) | Complete — 7 pages, type-safe API client |
+| Databases | PostgreSQL 17 + pgvector, SQL Server 2025 Express |
+| CI pipeline | Complete — ruff + mypy + pytest 80% coverage gate |
+| OpenSpec governance | Complete — 4 system specs, 5 archived changes, full workflow |
+| Pre-commit hooks | Configured — ruff lint + format |
+| DevContainer | Working — auto-starts all services |
 
-| Area | Status | Completion |
-|------|--------|------------|
-| Backend rearchitecture | Complete | 100% |
-| Frontend migration (React TS) | Complete | 100% |
-| pgvector migration | Complete | 100% |
-| Infrastructure (Docker, devcontainer) | Complete | 100% |
-| Backend test suite | Complete | 433+ tests, 80%+ coverage |
-| CI pipeline | Complete | lint + typecheck + tests |
-| CD pipeline | Placeholder | 0% (echo stubs) |
-| OpenSpec governance | Complete (core profile) | Phases 0-3 done |
-| DI refactor (Depends()) | Complete | All routes migrated |
+## Resolved in latest session (2026-04-06)
 
-### What changed since last review (2026-04-02)
+- CORS hardened — `allow_origins=["*"]` replaced with configurable `CORS_ORIGINS` env var
+- DataExplorerService refactored to use Repository Pattern (no more raw psycopg2/pyodbc)
+- Health/capabilities handlers migrated to Depends() injection
+- Token budget guard added to RAG pipeline (tiktoken-based, truncates context if over budget)
+- Test naming convention enforced across all 470+ tests
+- Pre-commit config, frontend .env.example added
+- OpenSpec verification rules and worktree parallel workflow documented
 
-1. **OpenSpec adopted** — replaced spec-kit. All governance artifacts migrated.
-2. **DI refactor complete** — all 4 route files migrated from `_service = XxxService()` to `Depends()`.
-3. **CI fully green** — ruff format + ruff check + mypy + pytest 80% coverage gate.
-4. **spec-kit removed** — `.specify/`, speckit agents/prompts, `pyproject.toml`, `.flake8` deleted.
-5. **Branches consolidated** — `feature/openspec-governance` merged to `develop` (PR #11).
-
----
-
-## What's Working
-
-### Frontend (React TypeScript)
-
-7 pages fully functional: Home, Dashboard, Catalog, Operations, Explorer, Embeddings, Chat.
-
-### Backend (FastAPI)
-
-- 10 API modules, 5 service modules, 2 repository implementations (Postgres + SQL Server)
-- DI via `Depends()` with type aliases (`StatsBombSvc`, `IngestionSvc`, `ExplorerSvc`)
-- 433+ tests passing (unit + API), 80%+ line coverage
-
-### Infrastructure
-
-- PostgreSQL 17 + pgvector, SQL Server 2025 Express (Docker Compose)
-- Devcontainer v2 (postCreate + postStart + health checks)
-- CI: `.github/workflows/ci.yml` (ruff, mypy, pytest with coverage gate)
-
-### Governance
-
-- `AGENTS.md` — single source of truth for all project rules
-- `openspec/specs/` — 4 system specs (api, rag, data, infra)
-- `openspec/changes/archive/` — 1 completed change (fix-dependency-injection)
-- OpenSpec commands for Claude Code and GitHub Copilot
-
----
-
-## What's Pending
-
-### High priority
-
-| Item | Description | Effort |
-|------|-------------|--------|
-| CORS hardening | `allow_origins=["*"]` likely still in `main.py` | 1h |
-| Integration tests | `backend/tests/integration/` is empty | 1-2 days |
-| sqlserver test fix | `test_event_json_data_empty_when_none` fails (`None == ""`) | 1h |
+## Pending
 
 ### Medium priority
 
-| Item | Description | Effort |
-|------|-------------|--------|
-| CD pipeline | `cd.yml` is placeholder (only `echo`) | 1 week |
-| DataExplorerService refactor | Direct DB access, should use `BaseRepository` | 2-3 days |
-| IngestionService refactor | Direct DB access, should use `BaseRepository` | 3-5 days |
-| mypy `warn_return_any` | Disabled — factory functions return `Any` | 1 day |
-| Frontend tests | No vitest or playwright configured | 1-2 weeks |
+| Item | Description |
+|------|-------------|
+| CD pipeline | `cd.yml` is placeholder (echo stubs) |
+| Integration tests | `backend/tests/integration/` is empty — needs live DB |
+| Frontend tests | No vitest or playwright configured |
+| IngestionService refactor | Direct DB access, should use Repository Pattern |
 
 ### Low priority
 
-| Item | Description | Effort |
-|------|-------------|--------|
-| Task runner | `Taskfile.yml` or `justfile` for bootstrap/migrate/seed/test | 1 week |
-| Structured logging | request_id, match_id, latency, token usage | 1 week |
-| Query caching | Frequently asked questions cache | 1 week |
-| OpenSpec expanded profile | `/opsx:verify`, `/opsx:sync` commands | 1-2 days |
-
----
-
-## Architecture Quality
-
-- Clean layer separation (API → Services → Repositories → Domain)
-- Type safety (Python type hints + TypeScript strict)
-- DI via `Depends()` (no module-level singletons)
-- Centralized configuration (Pydantic Settings)
-- OpenAPI documentation (auto-generated)
-- 433+ tests, 80% coverage gate in CI
-- Static analysis: ruff (lint + format) + mypy
-
----
-
-## Quick Start
-
-```bash
-git clone <repo> && cd RAG-Challenge
-git checkout develop
-cp .env.example .env.docker  # Edit with your OpenAI credentials
-docker compose up --build
-
-# Frontend: http://localhost:5173
-# Backend API: http://localhost:8000/docs
-```
-
----
-
-## Key References
-
-| File | Purpose |
-|------|---------|
-| [AGENTS.md](AGENTS.md) | All project rules |
-| [CLAUDE.md](CLAUDE.md) | Claude Code entry point |
-| [CHANGELOG.md](CHANGELOG.md) | Version history |
-| [docs/PLAN_OPENSPEC_ADOPTION.md](docs/PLAN_OPENSPEC_ADOPTION.md) | OpenSpec adoption plan |
-| [docs/conversation_log.md](docs/conversation_log.md) | AI session audit trail |
-| [docs/architecture.md](docs/architecture.md) | System architecture |
-| [docs/archive/](docs/archive/) | Completed migration plans |
+| Item | Description |
+|------|-------------|
+| Structured logging | request_id, match_id, latency, token usage |
+| Query caching | Cache for frequently asked questions |
+| Task runner | `Taskfile.yml` or `justfile` for common commands |
+| Release to main | Merge develop → main with tag v0.2.0 |

--- a/README.md
+++ b/README.md
@@ -1,569 +1,227 @@
-# Football Analytics Copilot - RAG Challenge
+# Football Analytics Copilot — RAG Challenge
 
-> AI-powered football match analysis using Retrieval-Augmented Generation (RAG) with Azure OpenAI and vector embeddings.
+AI-powered football match analysis using Retrieval-Augmented Generation (RAG) with OpenAI and vector embeddings over [StatsBomb open data](https://github.com/statsbomb/open-data).
 
-## Project Status
+## What it does
 
-**Current Version:** v4.0.0-dev — OpenSpec governance + DI refactor
-**Primary Branch:** `develop`
-**Architecture:** FastAPI + React TypeScript + PostgreSQL (pgvector) + SQL Server
-**Governance:** [OpenSpec](https://github.com/Fission-AI/OpenSpec) (spec-driven development)
-**Last Updated:** 2026-04-06
+Ask natural-language questions about a football match. The system retrieves the most relevant events via vector similarity search, builds a token-budgeted context, and sends it to an LLM for a grounded answer.
 
-### Current state
+**Example:** "Who scored the winning goal in the Euro 2024 final?" — the system finds the relevant events from the match, assembles context, and generates a detailed answer with sources.
 
-- Backend: FastAPI layered architecture, DI via `Depends()`, 433+ tests, 80%+ coverage
-- Frontend: React 18 + TypeScript + Tailwind, 7 pages
-- CI: ruff + mypy + pytest (GitHub Actions, all green)
-- Governance: OpenSpec with 4 system specs and full propose/apply/archive workflow
+## Quick start
 
-### Documentation
+### Option A: Docker (recommended)
 
-| Document | Purpose |
-|---|---|
-| [AGENTS.md](./AGENTS.md) | All project rules (architecture, DI, testing, git, security) |
-| [CHANGELOG.md](./CHANGELOG.md) | Version history and release notes |
-| [PROJECT_STATUS.md](./PROJECT_STATUS.md) | Current status and pending work |
-| [docs/PLAN_OPENSPEC_ADOPTION.md](./docs/PLAN_OPENSPEC_ADOPTION.md) | OpenSpec adoption plan |
-| [docs/conversation_log.md](./docs/conversation_log.md) | AI session audit trail |
-| [docs/architecture.md](./docs/architecture.md) | System architecture |
-| [docs/adr/](./docs/adr/) | Architecture Decision Records |
-| [docs/archive/](./docs/archive/) | Completed migration plans |
-
-### Branch governance
-
-This project uses [OpenSpec](https://github.com/Fission-AI/OpenSpec) for spec-driven development.
-The governance workflow (`/opsx:propose` → `/opsx:apply` → `/opsx:archive`) lives in `openspec/`.
-
-| Branch | Status | Purpose |
-|--------|--------|---------|
-| `main` | Active | Production — only admins merge via PR from `develop` |
-| `develop` | Active | Integration — all feature PRs target this branch |
-| `feature/openspec-governance` | Active | OpenSpec adoption (to be merged into `develop`) |
-| `feature/spec-kit-governance` | Obsolete | Initial governance attempt using spec-kit. Superseded by OpenSpec — kept for historical reference |
-| `feature/spec-kit-streamlit-app` | Obsolete | Governance artifacts for the old Streamlit architecture. Superseded by FastAPI migration — kept for historical reference |
-| `feature/010-speckit-audit` | Obsolete | spec-kit compliance audit. Superseded by OpenSpec adoption — kept for historical reference |
-
-> **Why the pivot?** We initially adopted [spec-kit](https://github.com/github/spec-kit) (sessions 1-12
-> in `docs/conversation_log.md`), but found OpenSpec to be a better fit for our multi-tool workflow
-> (GitHub Copilot + Claude Code). The spec-kit branches are preserved so the team can trace the
-> decision history. See `docs/PLAN_OPENSPEC_ADOPTION.md` for the full rationale.
-
----
-
-## 📐 Architecture
-
-### Current Architecture (v2.0)
-
-```
-┌──────────────────────────────────────────────┐
-│  Frontend (React + TypeScript) - Port 5173   │
-│  • Vite + TailwindCSS                        │
-│  • TanStack Query (state management)         │
-│  • React Router (navigation)                 │
-│  • Full UI: Dashboard, Catalog, Chat, etc.   │
-└──────────────┬───────────────────────────────┘
-               │ REST API
-               ↓
-┌──────────────────────────────────────────────┐
-│       Backend (FastAPI) - Port 8000          │
-│  ┌────────────────────────────────────────┐  │
-│  │ API Layer (v1)                         │  │
-│  │ • /health, /capabilities, /sources     │  │
-│  │ • /competitions, /matches, /events     │  │
-│  │ • /statsbomb, /ingestion, /explorer    │  │
-│  │ • /embeddings, /chat (RAG)             │  │
-│  └──────────┬─────────────────────────────┘  │
-│             ↓                                │
-│  ┌────────────────────────────────────────┐  │
-│  │ Services Layer                         │  │
-│  │ • SearchService (RAG orchestration)    │  │
-│  │ • IngestionService (data loading)      │  │
-│  │ • StatsBombService (remote catalog)    │  │
-│  │ • DataExplorerService (queries)        │  │
-│  │ • JobService (background tasks)        │  │
-│  └──────────┬─────────────────────────────┘  │
-│             ↓                                │
-│  ┌────────────────────────────────────────┐  │
-│  │ Repositories Layer                     │  │
-│  │ • PostgreSQL Repository                │  │
-│  │ • SQL Server Repository                │  │
-│  └──────────┬─────────────────────────────┘  │
-│             ↓                                │
-│  ┌─────────────────────────────────┐         │
-│  │ Adapters Layer                  │         │
-│  │ • OpenAI/Azure OpenAI           │         │
-│  └─────────────────────────────────┘         │
-└──────────────────────────────────────────────┘
-               │
-               ↓
-┌──────────────────────────────────────────┐
-│  Databases                               │
-│  • PostgreSQL + pgvector (embeddings)    │
-│  • SQL Server (relational data)          │
-└──────────────────────────────────────────┘
+```bash
+git clone https://github.com/erincon01/RAG-Challenge.git
+cd RAG-Challenge
+git checkout develop
+cp .env.docker.example .env.docker
+# Edit .env.docker — set OPENAI_KEY and OPENAI_ENDPOINT
+docker compose up --build
 ```
 
-### Key Features
+- Frontend: http://localhost:5173
+- Backend API: http://localhost:8000
+- API Docs: http://localhost:8000/docs
+- PostgreSQL: `localhost:5432`
+- SQL Server: `localhost:1433`
 
-#### Architecture & Infrastructure
-✅ **Layered Architecture**: Clean separation (API → Services → Repositories → Domain → Adapters)
-✅ **Multi-Database**: PostgreSQL (vector search) + SQL Server (relational data)
-✅ **Full Stack TypeScript**: React + TypeScript frontend with type-safe API client
-✅ **Containerized**: Complete Docker setup with docker-compose orchestration
-✅ **OpenAPI Docs**: Auto-generated interactive documentation at `/docs`
+### Option B: DevContainer (VS Code)
 
-#### Data & AI Capabilities
-✅ **Semantic Search**: Vector similarity search with multiple embedding models
-✅ **Multi-Model Support**: ada-002, text-embedding-3-small, 3-large, e5-large
-✅ **Multi-Algorithm**: Cosine similarity, inner product, L2 distance
-✅ **Multi-Language**: Automatic translation to English for search queries
-✅ **RAG-Powered Chat**: AI-generated answers with context from match data
+Open the repo in VS Code — it will offer to reopen in the DevContainer. All services start automatically.
 
-#### User Experience
-✅ **Modern Web UI**: 7 comprehensive pages (Dashboard, Catalog, Chat, Explorer, etc.)
-✅ **StatsBomb Integration**: Browse and import competitions/matches from open data
-✅ **Job Management**: Track downloads, imports, and processing with real-time status
-✅ **Dual Database Support**: Switch between PostgreSQL and SQL Server dynamically
-✅ **Embeddings Control**: View status and rebuild embeddings per match/model
-✅ **Developer & User Modes**: Simplified or advanced interface based on needs
+### Option C: Manual
 
----
+```bash
+# Backend
+cd backend
+pip install -r requirements.txt
+cp ../.env.example ../.env  # edit with your credentials
+python -m app.main
+# http://localhost:8000/docs
 
-## 🚀 Quick Start
+# Frontend
+cd frontend/webapp
+npm install
+cp .env.example .env
+npm run dev
+# http://localhost:5173
+```
 
-### Option A: Docker (Recommended)
+## Architecture
 
-The easiest way to run the full stack locally.
+```
+Frontend (React + TypeScript)          Backend (FastAPI)
+┌────────────────────────┐     REST   ┌─────────────────────────────┐
+│ Vite + Tailwind        │◄──────────►│ API Layer (v1)              │
+│ TanStack Query         │            │   ↓                        │
+│ 7 pages                │            │ Services Layer              │
+└────────────────────────┘            │   ↓                        │
+                                      │ Repositories (dual-repo)   │
+                                      │   ↓              ↓         │
+                                      │ PostgreSQL    SQL Server    │
+                                      │ (pgvector)    (VECTOR)      │
+                                      │   ↓                        │
+                                      │ OpenAI Adapter             │
+                                      └─────────────────────────────┘
+```
 
-**Prerequisites:** Docker and Docker Compose
+**Layers:** API → Services → Repositories → Domain → Adapters. One-way dependency rule — no layer imports from above. All external dependencies injected via FastAPI `Depends()`.
 
-1. **Clone and configure**
-   ```bash
-   git clone <repo-url>
-   cd RAG-Challenge
-   git checkout develop
-   ```
+See [docs/architecture.md](docs/architecture.md) for the full system design.
 
-2. **Set your OpenAI credentials** in `.env.docker`
-   ```bash
-   # Edit .env.docker with your Azure OpenAI key and endpoint
-   ```
+## Tech stack
 
-3. **Start everything**
-   ```bash
-   docker compose up --build
-   ```
+| Layer | Technology |
+|-------|-----------|
+| Backend | Python 3.11+, FastAPI, Pydantic v2, Uvicorn |
+| Frontend | React 18, TypeScript, Vite, Tailwind, TanStack Query |
+| Databases | PostgreSQL 17 + pgvector, SQL Server 2025 |
+| AI | OpenAI / Azure OpenAI (embeddings + chat completions) |
+| Infrastructure | Docker Compose, DevContainers, GitHub Actions CI |
+| Governance | [OpenSpec](https://github.com/Fission-AI/OpenSpec) spec-driven development |
+| Testing | pytest (470+ tests, 82% coverage), ruff, mypy |
 
-4. **Access the app**
-   - Frontend: <http://localhost:5173>
-   - Backend API: <http://localhost:8000>
-   - API Docs: <http://localhost:8000/docs>
-   - PostgreSQL: `localhost:5432` (user: `postgres`, db: `rag_challenge`) - *Solo con `--profile postgres`*
-   - SQL Server: `localhost:1433` (user: `sa`)
+See [docs/tech-stack.md](docs/tech-stack.md) for detailed versions and configuration.
 
-> **💡 PostgreSQL ahorra recursos:** Por defecto PostgreSQL no se inicia para ahorrar recursos. Para iniciarlo usa: `docker compose --profile postgres up`
+## Key features
 
-### Option B: Manual Setup
+- **Semantic search** with multiple embedding models (ada-002, text-embedding-3-small/large)
+- **Multiple search algorithms** (cosine, inner product, L2)
+- **Token budget guard** — counts tokens before LLM call, truncates context if needed
+- **Multi-language** — auto-translates queries to English
+- **Dual database** — PostgreSQL and SQL Server, switchable at query time
+- **StatsBomb integration** — browse and import competitions/matches from open data
+- **Job management** — track downloads, imports, embeddings with real-time status
+- **7-page web UI** — Dashboard, Catalog, Operations, Explorer, Embeddings, Chat, Data Sources
 
-**Prerequisites:**
+## Application pages
 
-- Python 3.11+, Node 20+
-- PostgreSQL 17 with pgvector OR Azure PostgreSQL Flexible Server
-- SQL Server 2025 Express OR Azure SQL Database
-- Azure OpenAI or OpenAI API access
+1. **Dashboard** — System health, database status, recent jobs
+2. **Data Sources** — Database connectivity and capability matrix
+3. **StatsBomb Catalog** — Browse and select competitions/matches
+4. **Operations** — Download, load, and process data with job tracking
+5. **Data Explorer** — Browse competitions, matches, teams, players, events
+6. **Embeddings** — Coverage status, rebuild embeddings per match/model
+7. **Chat** — AI-powered semantic search with natural language
 
-1. **Clone and configure**
-   ```bash
-   git clone <repo-url>
-   cd RAG-Challenge
-   git checkout develop
-   cp .env.example .env
-   # Edit .env with your database and OpenAI credentials
-   ```
+## API endpoints
 
-2. **Run the backend**
-   ```bash
-   cd backend
-   pip install -r requirements.txt
-   python -m app.main
-   # API: http://localhost:8000 | Docs: http://localhost:8000/docs
-   ```
+Full interactive documentation at http://localhost:8000/docs (Swagger) and http://localhost:8000/redoc.
 
-3. **Run the frontend**
-   ```bash
-   cd frontend/webapp
-   npm install
-   npm run dev
-   # Frontend: http://localhost:5173
-   ```
+| Group | Endpoints |
+|-------|-----------|
+| Health | `GET /health`, `/health/ready`, `/health/live` |
+| Capabilities | `GET /capabilities`, `/sources/status` |
+| StatsBomb | `GET /statsbomb/competitions`, `/statsbomb/matches` |
+| Data | `GET /competitions`, `/matches`, `/matches/{id}`, `/events`, `/events/{id}` |
+| Explorer | `GET /explorer/teams`, `/explorer/players`, `/explorer/tables` |
+| Ingestion | `POST /ingestion/download`, `/load`, `/aggregate` + job management |
+| Embeddings | `GET /embeddings/status`, `POST /embeddings/rebuild` |
+| Chat | `POST /chat/search` |
 
----
+All endpoints prefixed with `/api/v1`.
 
-## 📖 Documentation
+## Testing
 
-### Project & Architecture
+```bash
+cd backend
+pytest tests/ -v                                              # run all tests
+pytest tests/ --cov=app --cov-report=term-missing --cov-fail-under=80  # with coverage
+ruff check app/                                                # lint
+ruff format --check app/                                       # format check
+mypy app/                                                      # type check
+```
 
-| Document | Description |
-|---|---|
-| [CHANGELOG.md](./CHANGELOG.md) | Full version history |
-| [PROJECT_STATUS.md](./PROJECT_STATUS.md) | Current status and next steps |
-| [PLAN_REARQUITECTURA_COMPLETO.md](./PLAN_REARQUITECTURA_COMPLETO.md) | Full architecture roadmap |
-| [PLAN_MIGRACION_FRONTEND_WEB.md](./PLAN_MIGRACION_FRONTEND_WEB.md) | Frontend migration plan |
-| [docs/adr/README.md](./docs/adr/README.md) | Architecture Decision Records index |
-| [docs/adr/ADR-001](./docs/adr/ADR-001-layered-architecture.md) | Layered Architecture decision |
-| [docs/adr/ADR-002](./docs/adr/ADR-002-centralized-configuration.md) | Centralized Configuration decision |
-| [docs/adr/ADR-003](./docs/adr/ADR-003-pgvector-migration.md) | pgvector Migration decision |
-| [docs/adr/ADR-004](./docs/adr/ADR-004-local-docker-infrastructure.md) | Local Docker Infrastructure decision |
+CI runs all checks on every PR (GitHub Actions).
 
-### Backend (FastAPI)
-
-| Document | Description |
-|---|---|
-| [backend/README.md](./backend/README.md) | Backend overview, setup, deployment |
-| [backend/app/api/README.md](./backend/app/api/README.md) | HTTP endpoints, DTOs, validation |
-| [backend/app/services/README.md](./backend/app/services/README.md) | Business logic, orchestration |
-| [backend/app/repositories/README.md](./backend/app/repositories/README.md) | Data access patterns |
-| [backend/app/domain/README.md](./backend/app/domain/README.md) | Entities, value objects, rules |
-| [backend/app/adapters/README.md](./backend/app/adapters/README.md) | External integrations (OpenAI) |
-
-### Frontend (React TypeScript)
-
-| Document | Description |
-|---|---|
-| [frontend/webapp/README.md](./frontend/webapp/README.md) | React app setup and structure |
-| [config/README.md](./config/README.md) | Centralized configuration guide |
-
-### Domain Knowledge
-
-| Document | Description |
-|---|---|
-| [docs/statsbomb-intro.md](./docs/statsbomb-intro.md) | StatsBomb data structure explained |
-| [docs/app-use-case.md](./docs/app-use-case.md) | Application use cases and demo questions |
-| [docs/data-distribution.md](./docs/data-distribution.md) | Database statistics and data layout |
-
----
-
-## 🎨 The Application
-
-### Modern React Web Interface
-
-The application features a modern, responsive web interface built with React and TypeScript:
-
-#### Key Pages
-1. **Dashboard** - System health, database status, and recent jobs overview
-2. **Data Sources** - Database connectivity testing and capability matrix
-3. **StatsBomb Catalog** - Browse and select competitions/matches from open data
-4. **Operations** - Download, load, and process data with job tracking
-5. **Data Explorer** - Browse competitions, matches, teams, players, and events
-6. **Embeddings** - View coverage status and rebuild embeddings by match
-7. **Chat** - AI-powered semantic search with natural language queries
-
-#### Features
-- **Real-time Job Tracking**: Monitor downloads and imports with live status updates
-- **Multi-Database Support**: Switch between PostgreSQL and SQL Server seamlessly
-- **Capability-Aware UI**: Interface adapts based on available models/algorithms
-- **Responsive Design**: Built with TailwindCSS for modern, mobile-friendly layouts
-- **Type-Safe**: Full TypeScript coverage for reliability
-
-### Historical Streamlit Screenshots
-
-The repository still keeps screenshots from the original Streamlit prototype for historical reference only. The actively maintained product is the React frontend under `frontend/webapp/`.
-
-![User Mode](./images/app/image-26.png)
-![Developer Mode](./images/app/image-27.png)
-
-[More screenshots →](./docs/app-screenshots.md)
-
----
-
-## 🎥 Demo
-
-[8 minutes video of the Challenge](./RAG-Challenge_Sabados_Tech.mp4)
-
----
-
-## 🏗️ Project Structure
+## Project structure
 
 ```
 RAG-Challenge/
-├── backend/                           # FastAPI backend
+├── backend/                    # FastAPI backend
 │   ├── app/
-│   │   ├── api/v1/                   # HTTP endpoints (REST API)
-│   │   │   ├── capabilities.py       # System capabilities & DB status
-│   │   │   ├── statsbomb.py         # StatsBomb catalog API
-│   │   │   ├── ingestion.py         # Data ingestion & jobs
-│   │   │   ├── explorer.py          # Data browsing
-│   │   │   ├── embeddings.py        # Embeddings management
-│   │   │   ├── chat.py              # RAG chat endpoint
-│   │   │   ├── matches.py           # Match queries
-│   │   │   ├── events.py            # Event queries
-│   │   │   └── health.py            # Health checks
-│   │   ├── services/                 # Business logic
-│   │   │   ├── search_service.py    # RAG orchestration
-│   │   │   ├── ingestion_service.py # Data loading pipeline
-│   │   │   ├── job_service.py       # Background job management
-│   │   │   ├── statsbomb_service.py # StatsBomb API client
-│   │   │   └── data_explorer_service.py
-│   │   ├── repositories/             # Data access layer
-│   │   │   ├── postgres.py          # PostgreSQL repository
-│   │   │   └── sqlserver.py         # SQL Server repository
-│   │   ├── domain/                   # Domain entities & rules
-│   │   ├── adapters/                 # External integrations
-│   │   │   └── openai_client.py     # OpenAI/Azure OpenAI
-│   │   ├── core/                     # Config & dependencies
-│   │   │   └── capabilities.py      # Capability matrix
-│   │   └── main.py                   # FastAPI application
-│   ├── data/                         # Static data cache
-│   │   └── competitions.json        # StatsBomb catalog
-│   ├── tests/                        # Backend tests
-│   ├── Dockerfile                    # Backend container
+│   │   ├── api/v1/            # HTTP endpoints
+│   │   ├── services/          # Business logic (SearchService, IngestionService, ...)
+│   │   ├── repositories/      # Data access (PostgreSQL, SQL Server)
+│   │   ├── domain/            # Entities, exceptions
+│   │   ├── adapters/          # External integrations (OpenAI)
+│   │   └── core/              # Config, DI providers
+│   ├── tests/                 # 470+ tests (unit + API)
 │   └── requirements.txt
-│
-├── frontend/                          # Frontend applications
-│   └── webapp/                       # Primary React app
-│   │   ├── src/
-│   │   │   ├── pages/               # Application pages
-│   │   │   │   ├── HomePage.tsx     # Landing page
-│   │   │   │   ├── DashboardPage.tsx
-│   │   │   │   ├── CatalogPage.tsx  # StatsBomb browser
-│   │   │   │   ├── OperationsPage.tsx # Jobs & ingestion
-│   │   │   │   ├── ExplorerPage.tsx # Data explorer
-│   │   │   │   ├── EmbeddingsPage.tsx
-│   │   │   │   └── ChatPage.tsx     # RAG chat
-│   │   │   ├── components/
-│   │   │   │   ├── layout/          # Layout components
-│   │   │   │   └── ui/              # UI components
-│   │   │   ├── lib/
-│   │   │   │   ├── api/             # Type-safe API client
-│   │   │   │   │   ├── client.ts    # HTTP client
-│   │   │   │   │   └── types.ts     # TypeScript types
-│   │   │   │   ├── storage/         # Local storage
-│   │   │   │   └── queryClient.ts   # TanStack Query config
-│   │   │   ├── state/               # Global state
-│   │   │   ├── App.tsx              # Main app component
-│   │   │   └── main.tsx             # Entry point
-│   │   ├── Dockerfile
-│   │   ├── package.json
-│   │   ├── vite.config.ts
-│   │   └── tailwind.config.js
-│
-├── infra/                             # Infrastructure as code
-│   └── docker/
-│       ├── postgres/
-│       │   └── initdb/               # Init scripts + schema
-│       │       ├── 01-extensions.sql
-│       │       └── 02-schema.sql
-│       └── sqlserver/
-│           ├── Dockerfile            # Custom SQL Server image
-│           ├── setup.sh              # Custom entrypoint
-│           └── initdb/
-│               └── 01-schema.sql
-│
-├── config/                            # Centralized configuration
-│   ├── settings.py                   # Pydantic settings
-│   └── README.md
-│
-├── docs/                              # Documentation
-│   ├── adr/                          # Architecture Decision Records
-│   │   ├── ADR-001-layered-architecture.md
-│   │   ├── ADR-002-centralized-configuration.md
-│   │   ├── ADR-003-pgvector-migration.md (Accepted)
-│   │   └── ADR-004-local-docker-infrastructure.md
-│   ├── app-screenshots.md
-│   ├── app-use-case.md
-│   ├── statsbomb-intro.md
-│   └── *.md
-│
-├── docker-compose.yml                 # Full stack orchestration
-├── .env.docker                        # Docker environment (gitignored)
-├── .env.example                       # Environment template
-├── PLAN_REARQUITECTURA_COMPLETO.md   # Original roadmap
-├── PLAN_MIGRACION_FRONTEND_WEB.md    # Frontend migration plan
+├── frontend/webapp/           # React + TypeScript frontend
+│   ├── src/pages/             # 7 application pages
+│   ├── src/lib/api/           # Type-safe API client
+│   └── package.json
+├── config/                    # Centralized Pydantic settings
+├── infra/docker/              # Docker init scripts (postgres, sqlserver)
+├── openspec/                  # Spec-driven governance
+│   ├── specs/                 # System specs (api, rag, data, infra)
+│   └── changes/archive/       # Completed change artifacts
+├── docs/                      # Documentation
+│   ├── architecture.md        # System architecture
+│   ├── tech-stack.md          # Technology details
+│   ├── semantic-search.md     # Vector search explained
+│   ├── data-model.md          # Database schema
+│   ├── app-use-case.md        # Use cases and demo questions
+│   ├── statsbomb-intro.md     # StatsBomb data explained
+│   ├── conversation_log.md    # AI session audit trail
+│   ├── PLAN_OPENSPEC_ADOPTION.md  # Governance roadmap
+│   └── adr/                   # Architecture Decision Records
+├── .devcontainer/             # VS Code DevContainer
+├── .github/workflows/ci.yml  # CI pipeline
+├── docker-compose.yml         # Full stack orchestration
+├── .env.example               # Environment template
+├── .env.docker.example        # Docker environment template
+├── .pre-commit-config.yaml    # Ruff lint + format hooks
+├── CLAUDE.md                  # AI assistant entry point
+├── AGENTS.md                  # Project rules and conventions
+├── CHANGELOG.md               # Version history
 └── README.md
 ```
 
----
+## Documentation
 
-## 🔧 Troubleshooting
+| Document | Purpose |
+|----------|---------|
+| [docs/getting-started.md](docs/getting-started.md) | New contributor guide — setup, OpenSpec workflow, where to find things |
+| [AGENTS.md](AGENTS.md) | All project rules (architecture, DI, testing, git, security) |
+| [CLAUDE.md](CLAUDE.md) | AI assistant entry point — references all key files |
+| [CHANGELOG.md](CHANGELOG.md) | Version history |
+| [docs/architecture.md](docs/architecture.md) | System design and layer diagram |
+| [docs/tech-stack.md](docs/tech-stack.md) | Technology versions and configuration |
+| [docs/semantic-search.md](docs/semantic-search.md) | Vector search algorithms and models |
+| [docs/data-model.md](docs/data-model.md) | Database schema and entity model |
+| [docs/app-use-case.md](docs/app-use-case.md) | Use cases and demo questions |
+| [docs/statsbomb-intro.md](docs/statsbomb-intro.md) | StatsBomb data structure |
+| [docs/PLAN_OPENSPEC_ADOPTION.md](docs/PLAN_OPENSPEC_ADOPTION.md) | Governance roadmap with sources |
+| [docs/conversation_log.md](docs/conversation_log.md) | AI session audit trail |
+| [docs/adr/](docs/adr/) | Architecture Decision Records (4 ADRs) |
+| [openspec/specs/](openspec/specs/) | System specs (api, rag, data, infra) |
 
-### Frontend no se ve en Windows (Docker Desktop + WSL2)
+## For AI assistants
 
-Si el frontend no carga en el navegador:
+Start with [CLAUDE.md](CLAUDE.md). It points to [AGENTS.md](AGENTS.md) which has all project rules. Key commands, architecture constraints, testing requirements, and the OpenSpec governance workflow are all documented there.
 
-1. **Verifica que el contenedor esté corriendo:**
+## Troubleshooting
 
-   ```bash
-   docker compose ps
-   ```
+**Frontend not loading?** Check `docker compose ps` — all services should be `healthy`. If SQL Server shows `starting`, wait 30-60 seconds.
 
-2. **Revisa los logs:**
+**Database connection refused?** Inside the DevContainer, use service names (`postgres`, `sqlserver`) instead of `localhost`.
 
-   ```bash
-   docker compose logs frontend
-   ```
+**Tests failing?** Unit/API tests don't need a running database — they mock all external calls. Run `cd backend && pytest tests/ -v`.
 
-3. **Problemas comunes:**
-   - **Error de memoria (ENOMEM):** El file watcher de Vite puede fallar con volúmenes montados desde Windows. Solución: el proyecto está configurado para usar `serve` en lugar de `vite dev` en Docker.
+## Team
 
-   - **Puerto accesible pero sin respuesta:** Problema conocido de port forwarding entre Docker/WSL2 y Windows.
-     - **Solución A:** Abre directamente en navegador Windows: <http://localhost:5173>
-     - **Solución B:** Usa la IP del contenedor: `docker inspect rag-frontend | grep IPAddress`
-     - **Solución C:** Reinicia Docker Desktop
+[Sabados Tech](https://www.youtube.com/channel/UCw89YeTGdK74ZZ97_xcI2FA) — a group of friends from Argentina and Spain who share football and technology.
 
-   - **Aumentar límites de inotify (WSL2):**
+- [Eugenio Serrano](https://www.linkedin.com/in/eugenio-serrano/)
+- [José Mariano Álvarez](https://www.linkedin.com/in/josemarianoalvarez/)
+- [Eladio Rincón](https://www.linkedin.com/in/erincon/)
 
-     ```bash
-     sudo sysctl -w fs.inotify.max_user_watches=524288
-     sudo sysctl -w fs.inotify.max_queued_events=32768
-     sudo sysctl -w fs.inotify.max_user_instances=1024
-     ```
+Built for the [Microsoft RAG Hack Challenge](https://github.com/microsoft/RAG_Hack).
 
-### Backend no se conecta a las bases de datos
-
-Verifica que los contenedores de bases de datos estén saludables:
-
-```bash
-docker compose ps
-```
-
-Si SQL Server está `starting`, espera 30-60 segundos para que inicialice completamente.
-
----
-
-## 🔧 API Endpoints
-
-### Health & Capabilities
-- `GET /` - API information and version
-- `GET /api/v1/health` - Detailed health check
-- `GET /api/v1/health/ready` - Readiness probe (DB connectivity)
-- `GET /api/v1/health/live` - Liveness probe
-- `GET /api/v1/capabilities` - Supported models/algorithms by source
-- `GET /api/v1/sources/status` - Database connectivity status
-
-### StatsBomb Catalog
-- `GET /api/v1/statsbomb/competitions` - Browse available competitions
-- `GET /api/v1/statsbomb/matches` - Get matches by competition/season
-
-### Data Ingestion & Jobs
-- `POST /api/v1/ingestion/download` - Download StatsBomb data
-- `POST /api/v1/ingestion/load` - Load data into database
-- `POST /api/v1/ingestion/aggregate` - Create aggregated tables
-- `GET /api/v1/ingestion/jobs` - List all jobs
-- `GET /api/v1/ingestion/jobs/{id}` - Get job details
-- `POST /api/v1/ingestion/jobs/{id}/cancel` - Cancel running job
-- `DELETE /api/v1/ingestion/jobs` - Clear completed jobs
-
-### Data Retrieval
-- `GET /api/v1/competitions` - List loaded competitions
-- `GET /api/v1/matches` - List matches (with filters)
-- `GET /api/v1/matches/{id}` - Get match details
-- `GET /api/v1/events` - List match events
-- `GET /api/v1/events/{id}` - Get event details
-
-### Data Explorer
-- `GET /api/v1/explorer/teams` - List teams
-- `GET /api/v1/explorer/players` - List players
-- `GET /api/v1/explorer/tables` - Database table information
-
-### Embeddings Management
-- `GET /api/v1/embeddings/status` - Embeddings coverage status
-- `POST /api/v1/embeddings/rebuild` - Rebuild embeddings for matches
-
-### AI-Powered Search
-- `POST /api/v1/chat/search` - Semantic search with RAG-generated answers
-
-**Interactive API Documentation:**
-- Swagger UI: http://localhost:8000/docs
-- ReDoc: http://localhost:8000/redoc
-
----
-
-## 🧪 Testing
-
-```bash
-# Backend tests
-cd backend
-pytest
-
-# With coverage
-pytest --cov=app --cov-report=html
-```
-
-Current local status on `feature/tests-suite`: `259 passed`.
-
----
-
-## 🛠️ Technology Stack
-
-### Backend
-- **FastAPI** - Modern async web framework
-- **Pydantic** - Data validation and settings
-- **PostgreSQL + pgvector** - Vector similarity search
-- **SQL Server** - Relational data storage
-- **Azure OpenAI** - Embeddings and chat completions
-
-### Frontend
-- **React 19** - Modern UI framework
-- **TypeScript** - Type-safe JavaScript
-- **Vite** - Fast build tool and dev server
-- **TailwindCSS** - Utility-first CSS framework
-- **TanStack Query** - Data fetching and state management
-- **React Router** - Client-side routing
-
-### Infrastructure
-- **Docker & Docker Compose** - Full-stack containerization (`docker compose up`)
-- **pgvector/pgvector:pg17** - PostgreSQL with vector search (local Docker)
-- **SQL Server 2025 Express** - Linux container with VECTOR type support
-- **GitHub Actions** - CI/CD pipeline (coming soon)
-
----
-
-## 👥 Team: Sabados Tech
-
-Our team, [Sabados Tech](https://www.youtube.com/channel/UCw89YeTGdK74ZZ97_xcI2FA), is a passionate group of friends from Argentina and Spain who share two loves: football and technology.
-
-**Core Team:**
-- [Eugenio Serrano](https://www.linkedin.com/in/eugenio-serrano/) - SQL Server Former MVP
-- [José Mariano Álvarez](https://www.linkedin.com/in/josemarianoalvarez/) - SQL Server Former MVP
-- [Eladio Rincón](https://www.linkedin.com/in/erincon/) - .NET Former MVP
-
-**Contributors:**
-- [Eric](https://github.com/eric-net)
-- [Walter](https://github.com/Exodo77)
-- [Nestor](https://github.com/nnarvaez)
-
----
-
-## 🏆 Microsoft RAG Hack Challenge
-
-This project was developed for the [Microsoft RAG Hack Challenge](https://github.com/microsoft/RAG_Hack), showcasing the power of Retrieval-Augmented Generation on Azure.
-
-**Special Thanks:**
-- [Bruno Capuano](https://x.com/elbruno) - Microsoft
-- [Davide Mauri](https://x.com/mauridb) - Microsoft
-- [Altia](https://www.altia.es/)
-
-**Official Event:** [Microsoft Reactor](https://reactor.microsoft.com/es-es/reactor/events/23332/)
-
----
-
-## 🎯 Mission
-
-We'd love to secure Azure credits to process the full set of matches from [StatsBomb](https://github.com/statsbomb/open-data) and develop a Version 2.0 of this project.
-
-In the remote event that we win the challenge, we will donate the prize to [PROA school](https://www.cba.gov.ar/escuelas-proa/) in [Mina Clavero](https://www.minaclavero.gov.ar/), a fabulous city in the province of Cordoba, Argentina.
-
----
-
-## 📝 License
+## License
 
 MIT
-
----
-
-## 🌟 We Love Football!
-
-Football is more than a game to us—it's data, passion, and endless possibilities. With Azure and OpenAI, we're showing the world just how powerful these technologies can be in transforming the way we analyze the sport we love!
-
-⚽ **#Football #AI #RAG #Azure #OpenAI #DataScience**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,151 @@
+# Getting Started — RAG-Challenge
+
+Guide for new contributors (human or AI) to start producing in 10 minutes.
+
+## 1. Setup
+
+### DevContainer (recommended)
+
+Open the repo in VS Code — accept the "Reopen in Container" prompt. Everything starts automatically (backend, frontend, PostgreSQL, SQL Server).
+
+### Docker Compose (without DevContainer)
+
+```bash
+git clone https://github.com/erincon01/RAG-Challenge.git
+cd RAG-Challenge && git checkout develop
+cp .env.docker.example .env.docker   # edit: set OPENAI_KEY and OPENAI_ENDPOINT
+docker compose up --build
+```
+
+### Verify it works
+
+- Frontend: http://localhost:5173
+- Backend docs: http://localhost:8000/docs
+- Tests: `cd backend && pytest tests/ -v` (470+ tests, no DB needed)
+
+## 2. Understand the project
+
+| Read this | To understand |
+|-----------|--------------|
+| [README.md](../README.md) | What the project does, architecture, tech stack |
+| [AGENTS.md](../AGENTS.md) | All project rules — architecture, DI, testing, git, security |
+| [docs/architecture.md](architecture.md) | System design and layer diagram |
+| [docs/tech-stack.md](tech-stack.md) | Technology versions and configuration |
+| [openspec/specs/](../openspec/specs/) | Current system specs (api, rag, data, infra) |
+
+## 3. How to make changes (OpenSpec workflow)
+
+This project uses **spec-driven development** with [OpenSpec](https://github.com/Fission-AI/OpenSpec). Every change follows a 3-step process: **propose → apply → archive**.
+
+### Step 1: Propose
+
+Before writing code, create a change proposal:
+
+```
+/opsx:propose <change-name>
+```
+
+Example: `/opsx:propose add-rate-limiting`
+
+This generates 4 artifacts in `openspec/changes/<name>/`:
+- `proposal.md` — Why this change? What's affected?
+- `design.md` — How? File changes, approach, rollback strategy
+- `specs/<capability>/spec.md` — Delta spec (what behavior changes)
+- `tasks.md` — Implementation checklist grouped by layer
+
+### Step 2: Apply
+
+Implement the tasks from the proposal:
+
+```
+/opsx:apply <change-name>
+```
+
+The agent reads the tasks and implements them one by one, following TDD:
+1. Write the test (Red)
+2. Write the minimum code to pass (Green)
+3. Run `pytest` on the file before marking the task `[x]`
+4. Run the full suite before finishing
+
+### Step 3: Archive
+
+After the PR is merged:
+
+```
+/opsx:archive <change-name>
+```
+
+This moves the change to `openspec/changes/archive/` and syncs delta specs into the main specs at `openspec/specs/`.
+
+### Example: full cycle
+
+```
+# 1. Propose
+/opsx:propose fix-rate-limiting
+
+# 2. Review the artifacts in openspec/changes/fix-rate-limiting/
+#    Adjust if needed, then apply
+
+# 3. Apply (creates branch, implements tasks, runs tests)
+/opsx:apply fix-rate-limiting
+
+# 4. Create PR, get it reviewed and merged
+
+# 5. Archive
+/opsx:archive fix-rate-limiting
+```
+
+### Parallel changes
+
+If you have 2-3 independent changes (different files/layers), you can apply them in parallel using worktrees:
+
+1. Propose all changes on `develop` (sequential)
+2. Launch agents with `isolation: "worktree"` (one per change)
+3. Each produces a PR against `develop`
+4. Merge PRs sequentially
+
+See `AGENTS.md` § "Parallel development with worktrees" for rules.
+
+## 4. Key rules (summary)
+
+- **Architecture:** API → Services → Repositories → Domain → Adapters (one-way dependency)
+- **DI:** All dependencies via FastAPI `Depends()` — no module-level singletons
+- **Testing:** TDD, 80% coverage minimum, naming: `test_<method>_<scenario>_<expected>`
+- **Git:** Branch from `develop`, conventional commits, update CHANGELOG
+- **Security:** No `allow_origins=["*"]`, no hardcoded secrets, parameterized SQL only
+- **No AI attribution** in commits, PRs, or code
+
+## 5. Key commands
+
+```bash
+# Tests
+cd backend && pytest tests/ -v
+cd backend && pytest tests/ --cov=app --cov-fail-under=80
+
+# Lint & format
+ruff check backend/app
+ruff format backend/app
+
+# Type check
+mypy backend/app
+
+# Docker
+docker compose up --build
+```
+
+## 6. Where to find things
+
+| What | Where |
+|------|-------|
+| API endpoints | `backend/app/api/v1/` |
+| Business logic | `backend/app/services/` |
+| Database access | `backend/app/repositories/` (postgres.py, sqlserver.py) |
+| Domain entities | `backend/app/domain/entities.py` |
+| OpenAI integration | `backend/app/adapters/openai_client.py` |
+| DI providers | `backend/app/core/dependencies.py` |
+| Configuration | `config/settings.py` (Pydantic BaseSettings) |
+| Frontend pages | `frontend/webapp/src/pages/` |
+| API client | `frontend/webapp/src/lib/api/client.ts` |
+| System specs | `openspec/specs/{api,rag,data,infra}/spec.md` |
+| Archived changes | `openspec/changes/archive/` |
+| Test fixtures | `backend/tests/conftest.py` |


### PR DESCRIPTION
## Summary
- Rewrite README from scratch — clean, well-linked, no broken references
- Update PROJECT_STATUS with current resolved items and pending work
- Fix .gitignore with standard Python/Node patterns
- Consolidate CHANGELOG duplicate sections

## Goal
Someone cloning the repo with an LLM should be productive in 10 minutes.