### PR TITLE
chore: add .vite/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ pytest.out
 
 # Node
 node_modules/
+.vite/
 
 # IDE
 .DS_Store


### PR DESCRIPTION
## Summary
- Add `.vite/` (Vite cache directory) to `.gitignore` to prevent auto-generated files from being tracked

## Test plan
- [x] Verify `frontend/webapp/.vite/` no longer shows as untracked in `git status`