### PR TITLE
chore(infra): decouple devcontainer image from production backend image

### DIFF
--- a/.devcontainer/docker-compose.override.yml
+++ b/.devcontainer/docker-compose.override.yml
@@ -1,6 +1,15 @@
-# Override for VS Code Dev Containers
-# Backend uses sleep infinity so VS Code manages the process via post-start
+# Override for VS Code Dev Containers.
+#
+# Selects the `devcontainer` build target from backend/Dockerfile so the
+# image gets dev-only tooling (git, nodejs, openssh-client, ...) layered on
+# top of the lean `runtime` stage. Plain `docker compose up` from a shell
+# does NOT load this file, so production builds the default (runtime) target.
+#
+# Backend uses `sleep infinity` because VS Code manages uvicorn via
+# post-start.sh, not via the container's CMD.
 services:
   backend:
+    build:
+      target: devcontainer
     command: sleep infinity
     working_dir: /workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Security
 - Remove `git`, `nodejs`, and dev-only apt tooling from the production backend image, reducing attack surface and image size.
 
+### Fixed
+- Migrate class-based `Config` to `model_config = ConfigDict(...)` in all 7 response DTOs in `backend/app/api/v1/models.py`, eliminating `PydanticDeprecatedSince20` warnings. `pytest tests/ -v` now runs with zero warnings (was 7).
+
 ---
 
 ## [4.0.0] - 2026-04-06 — OpenSpec governance + security + DI refactor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+- **infra**: Split `backend/Dockerfile` into two stages — `runtime` (production) and `devcontainer` (dev only). The production image no longer carries `git`, `nodejs`, `gnupg2`, `apt-transport-https`, `openssh-client`, `less`, or `procps`. Those tools are layered on in the `devcontainer` stage, which is selected via `build.target: devcontainer` in `.devcontainer/docker-compose.override.yml` and is never built by plain `docker compose up`.
+- **infra**: Production backend container now runs as non-root `appuser` (UID 1000) by default — previously only the devcontainer enforced this.
+
+### Security
+- Remove `git`, `nodejs`, and dev-only apt tooling from the production backend image, reducing attack surface and image size.
+
 ---
 
 ## [4.0.0] - 2026-04-06 — OpenSpec governance + security + DI refactor

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,21 +1,43 @@
-FROM python:3.11-slim-bookworm
+# syntax=docker/dockerfile:1.7
+
+# =========================================================================
+# RUNTIME (production)
+# -------------------------------------------------------------------------
+# This stage ships to production. It must contain ONLY what the running
+# FastAPI backend needs at runtime. Do NOT add dev tooling (git, node,
+# editors, debuggers) here — put them in the `devcontainer` stage below.
+# =========================================================================
+FROM python:3.11-slim-bookworm AS runtime
 
 WORKDIR /app
 
-# Install system dependencies for pyodbc (SQL Server), psycopg2, and Node.js LTS
+# System deps for the running app:
+#   - ca-certificates: TLS for outbound calls (OpenAI, StatsBomb, etc.)
+#   - curl: kept because it's tiny and msodbcsql18 install needs it
+#   - libpq-dev + gcc: build psycopg2 from source
+#   - msodbcsql18 + unixodbc-dev: pyodbc driver for SQL Server
+#
+# gnupg2 and apt-transport-https are installed ONLY to add the Microsoft
+# apt repository key, then purged in the same layer to keep the final
+# image lean and to reduce production attack surface.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash gnupg2 curl apt-transport-https git ca-certificates \
-    # PostgreSQL client libs
-    libpq-dev gcc \
-    # Node.js LTS (for Claude CLI and tooling)
-    && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    # ODBC Driver 18 for SQL Server
-    && curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
-    && curl -fsSL https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+        ca-certificates \
+        curl \
+        libpq-dev \
+        gcc \
+        gnupg2 \
+        apt-transport-https \
+    && curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+        | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
+    && curl -fsSL https://packages.microsoft.com/config/debian/12/prod.list \
+        > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update \
-    && ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 unixodbc-dev \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && ACCEPT_EULA=Y apt-get install -y --no-install-recommends \
+        msodbcsql18 \
+        unixodbc-dev \
+    && apt-get purge -y --auto-remove gnupg2 apt-transport-https \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
 COPY backend/requirements.txt .
@@ -27,7 +49,8 @@ COPY config/ /config/
 # Copy backend application code
 COPY backend/ .
 
-# Create non-root user (switched at runtime via devcontainer.json remoteUser)
+# Create non-root user with stable UID/GID 1000 so bind mounts from the host
+# and from the devcontainer stage share ownership consistently.
 RUN groupadd --gid 1000 appuser \
     && useradd --uid 1000 --gid 1000 --create-home appuser \
     && chown -R appuser:appuser /app /config \
@@ -36,6 +59,47 @@ RUN groupadd --gid 1000 appuser \
 
 ENV PATH="/home/appuser/.local/bin:${PATH}"
 
+# Run as non-root by default in production
+USER appuser
+
 EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--loop", "asyncio"]
+
+
+# =========================================================================
+# DEVCONTAINER (dev only)
+# -------------------------------------------------------------------------
+# This stage is built ONLY when VS Code Dev Containers loads
+# `.devcontainer/docker-compose.override.yml`, which selects it via
+# `build.target: devcontainer`. Plain `docker compose up` never touches
+# this stage, so the tools below never land in production.
+#
+# Reuses the runtime stage as its base, so the lean production layers are
+# shared and cached between both images.
+# =========================================================================
+FROM runtime AS devcontainer
+
+USER root
+
+# Dev-only tooling:
+#   - git, openssh-client: source control from inside the container
+#   - gnupg2, apt-transport-https: reinstated for apt ops inside the container
+#   - less, procps: interactive use (paging, ps/top)
+#   - nodejs (LTS): required by the Claude CLI and other dev tooling
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        gnupg2 \
+        apt-transport-https \
+        openssh-client \
+        less \
+        procps \
+    && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Back to non-root for interactive dev use. VS Code honors this via
+# `remoteUser: appuser` in devcontainer.json.
+USER appuser
+WORKDIR /workspace

--- a/backend/app/api/v1/models.py
+++ b/backend/app/api/v1/models.py
@@ -9,7 +9,7 @@ transformation without affecting the domain layer.
 from datetime import date
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 # Competition models
@@ -20,8 +20,7 @@ class CompetitionResponse(BaseModel):
     country: str
     name: str
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Team models
@@ -35,8 +34,7 @@ class TeamResponse(BaseModel):
     manager: str | None = None
     manager_country: str | None = None
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Match models
@@ -54,8 +52,7 @@ class MatchSummaryResponse(BaseModel):
     result: str
     display_name: str
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class MatchDetailResponse(BaseModel):
@@ -75,8 +72,7 @@ class MatchDetailResponse(BaseModel):
     referee_name: str | None = None
     display_name: str
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Event models
@@ -92,8 +88,7 @@ class EventDetailResponse(BaseModel):
     summary: str | None = None
     time_description: str
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class SearchResultResponse(BaseModel):
@@ -103,8 +98,7 @@ class SearchResultResponse(BaseModel):
     similarity_score: float
     rank: int
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Search request/response models
@@ -166,8 +160,7 @@ class SearchResponse(BaseModel):
     match_info: MatchDetailResponse | None = None
     metadata: dict = Field(default_factory=dict)
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Pagination models

--- a/docs/conversation_log.md
+++ b/docs/conversation_log.md
@@ -74,6 +74,37 @@ Cada sesión significativa con un agente AI se documenta aquí para auditoría y
 
 ---
 
+### [2026-04-08] Session 20 — Decouple devcontainer image from production backend image (chore/decouple-devcontainer-image)
+
+**Participants:** Eladio Rincon + Claude Code (Claude Opus 4.6)
+**Branch:** chore/decouple-devcontainer-image
+
+#### Problem discovered
+- `.devcontainer/devcontainer.json` used the same `backend` service from `docker-compose.yml`, so the production `backend/Dockerfile` carried dev-only tooling: `git`, full Node.js LTS (`"for Claude CLI and tooling"`), `gnupg2`, `apt-transport-https`, and a self-describing comment about devcontainer's non-root user.
+- Result: production image inflated with dev tools, clear coupling of dev and prod concerns, confusing for new contributors.
+
+#### Decisions taken
+- Use **multi-stage in a single `backend/Dockerfile`** (`runtime` + `devcontainer`) instead of a separate `.devcontainer/Dockerfile`. Docker cannot `FROM` a stage defined in a different Dockerfile without workarounds; a single multi-stage file sidesteps that cleanly and lets `docker compose` switch between images via `build.target`.
+- The `runtime` stage purges `gnupg2` and `apt-transport-https` after installing `msodbcsql18`, since they're only needed for adding the MS apt key.
+- Add `USER appuser` at the end of the `runtime` stage so production also runs as non-root (previously only the devcontainer enforced this — bonus security fix found during design).
+- Keep `curl` in `runtime` because `msodbcsql18` install needs it and it's tiny.
+- Leave `ghcr.io/devcontainers/features/{git,github-cli}` in `devcontainer.json` unchanged — removing them is out of scope and could change behavior subtly.
+
+#### Files modified
+- `backend/Dockerfile` — split into `runtime` (production) and `devcontainer` (dev-only) stages
+- `.devcontainer/docker-compose.override.yml` — added `build.target: devcontainer`
+- `CHANGELOG.md` — entry under `## [Unreleased]`
+- `openspec/changes/decouple-devcontainer-image/{proposal,design,tasks}.md` — OpenSpec change
+
+#### Verification
+- **Static validation (done in-session):** YAML parses, Dockerfile re-read end-to-end, pytest `backend/tests -v` passes (470/470 tests), `ruff check` and `ruff format --check` clean.
+- **Docker build verification (deferred):** the session environment has no docker socket, so §5 and §6 of `tasks.md` (building runtime and devcontainer targets, confirming `git`/`node` absence in runtime and presence in devcontainer, re-running pytest inside the rebuilt devcontainer) remain as manual verification steps for the user before merging.
+
+#### Follow-up (same session)
+- Fixed the 7 pre-existing PydanticDeprecatedSince20 warnings in `backend/app/api/v1/models.py` by migrating class-based `Config` to `model_config = ConfigDict(...)`. Separate commit, same branch.
+
+---
+
 ## Fase spec-kit (Sessions 1-12, branch: develop)
 
 ---

--- a/openspec/changes/decouple-devcontainer-image/design.md
+++ b/openspec/changes/decouple-devcontainer-image/design.md
@@ -1,0 +1,350 @@
+## Context
+
+Today, the devcontainer and the production backend image are the same thing.
+`.devcontainer/devcontainer.json` declares:
+
+```json
+"dockerComposeFile": ["../docker-compose.yml", "docker-compose.override.yml"],
+"service": "backend"
+```
+
+and the override only does:
+
+```yaml
+services:
+  backend:
+    command: sleep infinity
+    working_dir: /workspace
+```
+
+So when VS Code "Reopens in Container", it literally builds and runs the same image
+that `docker-compose.yml` would start with `uvicorn` — but idled with `sleep infinity`.
+The image is built from `backend/Dockerfile`, which today includes a lot of
+development-only tools (see proposal for the full list).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `backend/Dockerfile` produce an image that contains **only** what production needs.
+- Move all dev-only tooling to a separate `.devcontainer/Dockerfile` that extends the
+  runtime image.
+- Keep `docker compose up` behavior unchanged for plain-shell developers and CI.
+- Keep `"Reopen in Container"` behavior unchanged from the developer's point of view
+  (same mounts, same ports, same user, same `sleep infinity`, same `features`).
+- Keep the `appuser` UID/GID (1000) stable across both images so bind-mount permissions
+  on `.`, `backend/`, and `config/` don't break.
+
+**Non-Goals:**
+- Not optimizing the runtime image aggressively (no Alpine migration, no distroless,
+  no `pip install --no-deps`). The goal is separation, not minimization.
+- Not changing the frontend Dockerfile (`frontend/webapp/Dockerfile` is already
+  multi-stage and well-separated).
+- Not introducing `devcontainer.json` "image" mode. We stay on compose-based devcontainers
+  so the full stack (postgres, sqlserver, frontend) still comes up together.
+- Not changing the `features` block, the VS Code extensions list, or the post-create /
+  post-start scripts.
+
+## Decisions
+
+### 1. Explain the "why" in plain terms first
+
+The user is not a Docker expert. The mental model to keep in mind while implementing:
+
+> A Docker image is a box of software. Right now, the box we ship to production is the
+> same box we work inside. Every time we add a tool for ourselves (a Node.js runtime,
+> git, a debugger) the production box gets bigger and has more moving parts that could
+> break or be attacked. We want two boxes: a small one for production, and a bigger one
+> we only use on our laptops that **reuses the small one as its starting point** — so
+> production never sees the dev tools, and we never accidentally ship them.
+
+This framing drives every decision below.
+
+### 2. Multi-stage `backend/Dockerfile` with an explicit `runtime` target
+
+The new structure:
+
+```dockerfile
+# ---- Stage 1: runtime (production image) ----
+FROM python:3.11-slim-bookworm AS runtime
+
+WORKDIR /app
+
+# Only what the running FastAPI app needs:
+# - libpq-dev + gcc: build psycopg2 from source
+# - msodbcsql18 + unixodbc-dev: pyodbc driver for SQL Server
+# - ca-certificates: TLS for outbound calls (OpenAI, etc.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      libpq-dev gcc \
+      gnupg2 curl apt-transport-https \
+    && curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+         | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
+    && curl -fsSL https://packages.microsoft.com/config/debian/12/prod.list \
+         > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update \
+    && ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 unixodbc-dev \
+    # Remove build-only packages and the apt key tooling after msodbcsql18 is installed
+    && apt-get purge -y --auto-remove gnupg2 apt-transport-https \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY backend/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY config/ /config/
+COPY backend/ .
+
+RUN groupadd --gid 1000 appuser \
+ && useradd --uid 1000 --gid 1000 --create-home appuser \
+ && chown -R appuser:appuser /app /config \
+ && mkdir -p /home/appuser/.local/bin \
+ && chown -R appuser:appuser /home/appuser
+
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+USER appuser
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--loop", "asyncio"]
+```
+
+**Key differences from today:**
+
+- **No `git`.** The running backend never needs git. Developers get it in the dev image.
+- **No Node.js.** Removed the `curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -`
+  and the `apt-get install nodejs` line. This is the biggest win — Node.js was only
+  there for the Claude CLI, which is a developer tool.
+- **`gnupg2` and `apt-transport-https` are purged** after they're used to add the
+  Microsoft apt key and install `msodbcsql18`. They are not part of the runtime surface.
+- **`curl` is kept in runtime** because `msodbcsql18` installation needs it and
+  removing it would complicate the dev image. Acceptable trade-off — curl alone is small
+  and comes with the slim image anyway.
+- **`USER appuser` is set at the end** so the container actually runs as non-root by
+  default (today this is only done via the devcontainer). Production compose will also
+  benefit.
+
+The stage is explicitly named `AS runtime` so the devcontainer Dockerfile can depend on it.
+
+### 3. New `.devcontainer/Dockerfile` extending the runtime stage
+
+```dockerfile
+# Build on top of the backend runtime image. This must be built by Docker Compose
+# with build context set to the repo root so it can reference ../backend/Dockerfile.
+ARG BACKEND_IMAGE=rag-backend-runtime
+FROM ${BACKEND_IMAGE} AS devcontainer
+
+USER root
+
+# Dev-only tooling. This layer is never pulled in by production.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash \
+      git \
+      gnupg2 \
+      apt-transport-https \
+      openssh-client \
+      less \
+      procps \
+ && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Back to non-root for interactive use
+USER appuser
+WORKDIR /workspace
+```
+
+**Notes:**
+
+- Uses the same `appuser` (UID/GID 1000) that the runtime stage created, so bind mounts
+  work without permission hacks.
+- Re-adds the tools that were yanked out of runtime: `git`, `gnupg2`, `apt-transport-https`,
+  `openssh-client`, `less`, `procps`, and the Node.js LTS runtime for the Claude CLI.
+- The `ghcr.io/devcontainers/features/{git,github-cli}:1` features in `devcontainer.json`
+  still apply — they layer on top of this image at devcontainer-start time. We keep
+  them for now to avoid touching too much at once.
+
+### 4. Compose override: tell devcontainer to build from `.devcontainer/Dockerfile`
+
+The trick is that `.devcontainer/docker-compose.override.yml` is only loaded when VS Code
+starts the devcontainer (via `dockerComposeFile` array in `devcontainer.json`). A plain
+`docker compose up` from the shell does **not** load it. So we can freely override
+`build:` there without affecting production.
+
+New override:
+
+```yaml
+services:
+  backend:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+      args:
+        BACKEND_IMAGE: rag-backend-runtime
+    image: rag-backend-devcontainer
+    command: sleep infinity
+    working_dir: /workspace
+```
+
+**How the two build paths coexist:**
+
+| Invocation | Loads override? | Image built | Tool |
+|---|---|---|---|
+| `docker compose up --build` (shell) | No | `backend/Dockerfile` → `runtime` stage | Production runtime |
+| VS Code "Reopen in Container" | Yes | `.devcontainer/Dockerfile` (FROM `rag-backend-runtime`) | Devcontainer image |
+
+**Prerequisite:** for the devcontainer build to work, the `rag-backend-runtime` image
+must exist locally first. VS Code runs `docker compose build` using both compose files,
+which builds all services — but because the override changes `backend.build.dockerfile`,
+compose will build the devcontainer directly and the `FROM rag-backend-runtime` inside
+it will fail unless we either:
+
+- **(Option A)** Explicitly build the runtime stage first, tagged as `rag-backend-runtime`.
+- **(Option B)** Make `.devcontainer/Dockerfile` reference the upstream image by building
+  it inline in a multi-step compose setup.
+
+We pick **Option A** and add a `postCreateCommand` hook — or better, a script invoked
+from `post-create.sh` — that runs:
+
+```bash
+docker compose -f docker-compose.yml build backend
+docker tag rag-challenge-backend rag-backend-runtime  # idempotent
+```
+
+No — that can't work because the devcontainer needs the image **before** it can run
+`post-create.sh` (which runs inside the container).
+
+Revised approach — **Option A'**: use a **`target:`** in the override so the devcontainer
+build chain itself invokes the runtime stage:
+
+```yaml
+services:
+  backend:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+      args:
+        BACKEND_IMAGE_STAGE: runtime
+    command: sleep infinity
+    working_dir: /workspace
+```
+
+And the new `.devcontainer/Dockerfile` becomes:
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+# First bring in the runtime stage from backend/Dockerfile
+FROM scratch AS _placeholder
+# Actual base: the runtime stage of backend/Dockerfile.
+# We achieve this by copying backend/Dockerfile's runtime stage via multi-stage cross-file
+# is NOT supported directly — so instead we simply inline a FROM on the same base and
+# re-do the COPY. This would duplicate work.
+```
+
+This doesn't work cleanly either — Docker can't `FROM` a stage defined in a **different**
+Dockerfile. So we need a third option.
+
+**Option C (chosen)**: use **two stages inside `backend/Dockerfile`** — `runtime` and
+`devcontainer` — and let the override select the `devcontainer` target. This keeps
+everything in one file that Docker Compose can build with a simple `target:` switch.
+
+Revised `backend/Dockerfile`:
+
+```dockerfile
+FROM python:3.11-slim-bookworm AS runtime
+# ... (lean runtime as above) ...
+USER appuser
+CMD ["uvicorn", ...]
+
+FROM runtime AS devcontainer
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git gnupg2 apt-transport-https openssh-client less procps \
+ && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+USER appuser
+WORKDIR /workspace
+```
+
+And `.devcontainer/docker-compose.override.yml` becomes:
+
+```yaml
+services:
+  backend:
+    build:
+      target: devcontainer
+    command: sleep infinity
+    working_dir: /workspace
+```
+
+This is clean because:
+- `docker compose up` (no override) builds the default target → `runtime` → lean prod image.
+- VS Code loads the override → `target: devcontainer` → the second stage, which is built
+  on top of `runtime` and adds the dev tools.
+- **Both images share the same base layers**, so rebuilds are fast and disk usage is low.
+- No separate `.devcontainer/Dockerfile` file is needed, which sidesteps the "Docker
+  can't FROM across files" limitation.
+
+**Trade-off:** the dev tools live inside `backend/Dockerfile` instead of under
+`.devcontainer/`. That is a minor cosmetic loss — we clearly mark the stage with a
+comment banner, and the separation of concerns is enforced by the `target:` selector,
+which is what actually matters.
+
+### 5. Keep `.devcontainer/Dockerfile` or not?
+
+Given Option C above, we do **not** create a separate `.devcontainer/Dockerfile`.
+The proposal.md mentioned one, but the design decision is to put both stages in
+`backend/Dockerfile`. Update proposal.md to match at implementation time — or keep it
+for future if we ever want to fully detach. For this change: single file, two stages.
+
+### 6. Non-root at the runtime stage
+
+Today `backend/Dockerfile` creates `appuser` but never `USER appuser`s to it. The running
+container is root-by-default unless the devcontainer override intercepts. That's a
+security smell the cleanup should fix: add `USER appuser` at the end of the `runtime`
+stage so `docker compose up` also runs non-root in production.
+
+The `devcontainer` stage must `USER root` to install packages and `USER appuser` again
+before finishing. VS Code will then honor `remoteUser: appuser` from `devcontainer.json`
+as before.
+
+## File changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `backend/Dockerfile` | (modified) | Split into `runtime` and `devcontainer` stages. Strip git/nodejs/gnupg2/apt-transport-https from runtime. Add `USER appuser` at end of runtime. |
+| `.devcontainer/docker-compose.override.yml` | (modified) | Add `build.target: devcontainer` so VS Code builds the dev stage |
+| `CHANGELOG.md` | (modified) | Add entry under `## [Unreleased]` |
+| `docs/conversation_log.md` | (modified) | Session entry |
+
+(No new files — the single Dockerfile with two stages replaces the originally planned
+`.devcontainer/Dockerfile`.)
+
+## Risks / Trade-offs
+
+- **[Risk]** Switching `backend/Dockerfile` to `USER appuser` at the end of `runtime`
+  may break anything that currently assumes root inside the running container (e.g.,
+  writing to paths outside `/app`, `/config`, `/home/appuser`). **Mitigation:**
+  verify the backend still starts under `docker compose up` and that `/app/data`,
+  `/config` etc. are readable/writable as owned by `appuser:appuser` (they already are
+  per the existing `chown`).
+
+- **[Risk]** First devcontainer rebuild after this change will be slower for everyone,
+  because the `devcontainer` stage is new. **Mitigation:** one-time cost. Document in
+  CHANGELOG.
+
+- **[Risk]** The `features` block (`ghcr.io/devcontainers/features/git`,
+  `github-cli`) may layer duplicate tooling on top of the dev stage. **Mitigation:**
+  Accept the overlap for this PR. Removing the features block is out of scope — it
+  would change devcontainer behavior subtly (the features do more than install binaries).
+  Track as future cleanup.
+
+- **[Trade-off]** The devcontainer stage lives inside `backend/Dockerfile`, not under
+  `.devcontainer/`. Accepted for simplicity (see Decision §4).
+
+- **[Risk]** `post-create.sh` / `post-start.sh` may rely on tools that were only in the
+  old single-image layout. **Mitigation:** read both scripts during implementation and
+  verify every command they run is available in the `devcontainer` stage; add missing
+  tools to the dev stage if needed.
+
+## Rollback strategy
+
+Revert the single commit. The change is infra-only, one Dockerfile plus a one-line
+override bump. No database, no data, no API change. Rollback is trivial.

--- a/openspec/changes/decouple-devcontainer-image/proposal.md
+++ b/openspec/changes/decouple-devcontainer-image/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+The VS Code Dev Container is currently mounted directly on the **production backend image**.
+`.devcontainer/devcontainer.json` points to the root `docker-compose.yml` and selects
+`service: backend`, and `.devcontainer/docker-compose.override.yml` only changes the
+command to `sleep infinity`. There is no separate dev image.
+
+As a consequence, `backend/Dockerfile` — the image that is supposed to ship to production —
+has been polluted with dev-only tooling to satisfy the devcontainer:
+
+- `git`, `curl`, `gnupg2`, `apt-transport-https` (kept as permanent layers, not build-only)
+- **Full Node.js LTS runtime** installed with an explicit comment `"for Claude CLI and tooling"`
+- A self-describing comment on the non-root user: `"switched at runtime via devcontainer.json remoteUser"`
+
+This is a real problem, not a cosmetic one:
+
+1. **Production image size & attack surface.** Every dev tool inside the runtime image
+   is a potential CVE target in production (Node.js alone is ~150 MB + ecosystem).
+2. **Coupling dev and prod concerns.** Any new dev tool (debugpy, ipython, ssh keys,
+   language servers, SDKs) has to be added to the production Dockerfile or awkwardly
+   worked around.
+3. **Clarity.** New contributors can't tell which lines of `backend/Dockerfile` are
+   required for production versus which exist only for the devcontainer.
+
+Fixing now because we are approaching production readiness and v5 planning is in motion.
+
+## What Changes
+
+- Refactor `backend/Dockerfile` into a **multi-stage build** with a lean `runtime` stage
+  that contains only what production needs (Python deps, `libpq-dev`, `msodbcsql18`,
+  app code, non-root user). Remove `git`, `curl` (as permanent tool), `gnupg2`,
+  `apt-transport-https`, and Node.js from `runtime`.
+- Add a new **`.devcontainer/Dockerfile`** that builds `FROM` the runtime stage and
+  adds dev-only tooling (git, curl, gnupg2, Node.js LTS, anything Claude CLI needs,
+  plus whatever the `features` block assumes).
+- Update **`.devcontainer/docker-compose.override.yml`** so the `backend` service, when
+  launched through VS Code Dev Containers, is rebuilt from `.devcontainer/Dockerfile`.
+  Plain `docker compose up --build` from a shell must continue to use the lean runtime
+  image unchanged.
+- Keep everything else identical: `remoteUser: appuser`, UID/GID 1000, volume mounts
+  (`.:/workspace`, `./backend:/app`, `./config:/config`), forwarded ports, networks,
+  env vars, and the `sleep infinity` pattern for the devcontainer.
+- Update CHANGELOG `## [Unreleased]`.
+
+## Capabilities
+
+### New Capabilities
+
+(none — this is an infra refactor, not a feature)
+
+### Modified Capabilities
+
+- `infra`: The backend Docker image split into a production `runtime` stage and a
+  separate devcontainer image that extends it. The two images diverge cleanly.
+
+## Impact
+
+- **Affected layers:** Infra only. No Python, no tests, no API changes.
+- **Affected files:**
+  - `backend/Dockerfile` (modified → multi-stage)
+  - `.devcontainer/Dockerfile` (new)
+  - `.devcontainer/docker-compose.override.yml` (modified → adds `build:` override)
+  - `CHANGELOG.md` (modified → `## [Unreleased]`)
+  - `docs/conversation_log.md` (modified → session entry)
+- **Test impact:** No new Python tests. Verification is manual/operational:
+  1. `docker compose build backend` produces the lean runtime image.
+  2. `docker compose up backend` starts uvicorn normally.
+  3. Rebuilding the devcontainer in VS Code produces the dev image and `pytest tests/ -v`
+     still passes inside it.
+- **Backwards compatibility:** Fully compatible for anyone running `docker compose up`.
+  For devcontainer users, the **first** "Reopen in Container" after this change will
+  trigger a rebuild — that is the only user-visible disruption.
+- **Breaking:** None.

--- a/openspec/changes/decouple-devcontainer-image/tasks.md
+++ b/openspec/changes/decouple-devcontainer-image/tasks.md
@@ -1,0 +1,69 @@
+## 1. Branch & prep
+
+- [x] 1.1 From `develop`, create branch `chore/decouple-devcontainer-image`
+- [x] 1.2 Read `backend/Dockerfile`, `.devcontainer/devcontainer.json`, `.devcontainer/docker-compose.override.yml`, `.devcontainer/post-create.sh`, `.devcontainer/post-start.sh`, and `docker-compose.yml` end-to-end to confirm no hidden dependency on current tooling layout
+
+## 2. Refactor `backend/Dockerfile` into multi-stage
+
+- [x] 2.1 Rewrite `backend/Dockerfile` with an explicit `FROM python:3.11-slim-bookworm AS runtime` stage containing ONLY: `ca-certificates`, `curl`, `libpq-dev`, `gcc`, `gnupg2` (transient), `apt-transport-https` (transient), `unixodbc-dev`, `msodbcsql18`, Python deps, `/config/`, `/app/` code, `appuser` (UID/GID 1000)
+- [x] 2.2 Purge `gnupg2` and `apt-transport-https` with `apt-get purge -y --auto-remove` at the end of the runtime layer, after the MS key has been added and `msodbcsql18` installed
+- [x] 2.3 Remove ALL Node.js installation from the `runtime` stage (the `curl ... setup_lts.x | bash -` line and the `nodejs` apt package)
+- [x] 2.4 Remove `git` from the `runtime` stage
+- [x] 2.5 Add `USER appuser` at the end of the `runtime` stage so the production image runs non-root by default
+- [x] 2.6 Append a second stage `FROM runtime AS devcontainer` that `USER root`s, installs dev tools (`git`, `gnupg2`, `apt-transport-https`, `openssh-client`, `less`, `procps`, Node.js LTS via the NodeSource script), cleans apt lists, then switches back to `USER appuser` and sets `WORKDIR /workspace`
+- [x] 2.7 Add a comment banner above each stage: `# =========== RUNTIME (production) ===========` and `# =========== DEVCONTAINER (dev only) ===========`
+
+## 3. Update `.devcontainer/docker-compose.override.yml`
+
+- [x] 3.1 Add a `build:` block to the `backend` service with `target: devcontainer` so VS Code builds the second stage. Keep `command: sleep infinity` and `working_dir: /workspace`
+- [x] 3.2 Do NOT add `build.context` or `build.dockerfile` — compose will inherit them from the base `docker-compose.yml` and only override the `target`
+
+## 4. Sanity-check the devcontainer scripts
+
+- [x] 4.1 Re-read `.devcontainer/post-create.sh` and confirm every binary it uses (`pip`, `python`, `bash`) is present in the `devcontainer` stage — all present (inherited from `runtime`)
+- [x] 4.2 Re-read `.devcontainer/post-start.sh` and confirm every binary it uses (`nohup`, `uvicorn` via pip-installed deps, `python`, `requests` via requirements.txt) is present — all present
+- [x] 4.3 `nohup` is part of coreutils which is present in `python:3.11-slim-bookworm` — no action needed
+
+## 5. Verify `docker compose up` (production path) — **DEFERRED: requires user to run on host**
+
+> The session environment has no docker socket, so these verifications are deferred to the user before merging.
+
+- [ ] 5.1 Run `docker compose build backend` with NO devcontainer override and confirm the default target is `runtime`
+- [ ] 5.2 Inspect the resulting image: `docker run --rm rag-challenge-backend which git` MUST fail (git absent) and `docker run --rm rag-challenge-backend which node` MUST fail (node absent)
+- [ ] 5.3 Run `docker compose up backend postgres sqlserver` and confirm uvicorn starts normally and `GET /api/v1/health/live` returns 200
+- [ ] 5.4 Confirm the container runs as `appuser` (not root): `docker compose exec backend id` MUST show `uid=1000(appuser)`
+
+## 6. Verify VS Code "Reopen in Container" (dev path) — **DEFERRED: requires user to run on host**
+
+> The session environment has no docker socket, so these verifications are deferred to the user before merging.
+
+- [ ] 6.1 From a clean state, run: `docker compose -f docker-compose.yml -f .devcontainer/docker-compose.override.yml build backend` and confirm the `devcontainer` target is built
+- [ ] 6.2 Start the stack with both compose files and exec into the backend container: `which git` MUST succeed, `which node` MUST succeed, `id` MUST still show `appuser`
+- [ ] 6.3 Inside that container, run `cd /app && pytest tests/ -v` and confirm the full suite still passes (this is the dev-environment smoke test)
+- [ ] 6.4 Confirm volume mounts still work: `touch /workspace/_sanity_check && rm /workspace/_sanity_check` must succeed as `appuser`
+
+## 7. Update CHANGELOG & docs
+
+- [x] 7.1 Add entry under `## [Unreleased]` in `CHANGELOG.md`
+- [x] 7.2 Append a session entry to `docs/conversation_log.md` describing the decoupling and linking to this OpenSpec change
+
+## 8. Lint, format, and final verification
+
+- [x] 8.1 Run `ruff check backend/app` and `ruff format --check backend/app` — both clean (33 files already formatted)
+- [x] 8.2 Run `pytest tests/ -v` against the current code (smoke test, not against rebuilt image) — **470/470 tests passing**
+- [ ] 8.3 Confirm `docker compose up` (plain) still boots the full stack and `/api/v1/health/ready` returns 200 — **DEFERRED (see §5)**
+
+## 9. Commit & PR
+
+- [ ] 9.1 Stage only the changed files: `backend/Dockerfile`, `.devcontainer/docker-compose.override.yml`, `CHANGELOG.md`, `docs/conversation_log.md`, `openspec/changes/decouple-devcontainer-image/**`
+- [ ] 9.2 Commit with Conventional Commits, e.g. `chore(infra): split backend Dockerfile into runtime and devcontainer stages`. **No AI attribution**.
+- [ ] 9.3 Push the branch and open a PR against `develop` with a body linking to this OpenSpec change and summarizing the motivation
+- [ ] 9.4 After merge, run `/opsx:archive decouple-devcontainer-image`
+
+---
+
+### Verification rules (from project config)
+
+- **Never mark a task `[x]` without running the verification it implies.** For §5 and §6, that means the actual `docker` and `pytest` commands, not just reading the file.
+- If §6.3 (`pytest tests/ -v`) fails, STOP. Do not continue to §7. Fix the cause first — most likely a tool missing from the `devcontainer` stage.
+- Run `ruff check` and `ruff format --check` before §9.1 even though no Python changed (defensive).


### PR DESCRIPTION
## Summary

- Splits `backend/Dockerfile` into two stages (`runtime` and `devcontainer`) so the production image stops carrying dev-only tooling (`git`, Node.js LTS, `gnupg2`, `apt-transport-https`).
- `.devcontainer/docker-compose.override.yml` now selects the `devcontainer` stage via `build.target`. Plain `docker compose up` keeps building the lean `runtime` stage unchanged.
- Production backend container now runs as non-root `appuser` by default (previously only the devcontainer enforced this).
- Bonus: fixes 7 pre-existing `PydanticDeprecatedSince20` warnings by migrating class-based `Config` → `model_config = ConfigDict(...)` in `backend/app/api/v1/models.py`. `pytest` now runs with 0 warnings.

Full proposal, design rationale, and task list live in [`openspec/changes/decouple-devcontainer-image/`](../tree/chore/decouple-devcontainer-image/openspec/changes/decouple-devcontainer-image).

## Why

The devcontainer was mounted directly on the production `backend` service, so `backend/Dockerfile` had been silently accumulating dev-only tooling with comments like `"for Claude CLI and tooling"`. This inflated the production image, expanded its attack surface, and blurred the line between dev and prod concerns. Fixed now because we're approaching production readiness and v5 planning is in motion.

## Test plan

Static verification done in the proposal session:

- [x] `pytest backend/tests/ -v` → 470/470 passing, **0 warnings** (was 7)
- [x] `ruff check backend/app` clean
- [x] `ruff format --check backend/app` clean (33 files)
- [x] YAML of `.devcontainer/docker-compose.override.yml` parses
- [x] `backend/Dockerfile` re-read end-to-end; `post-create.sh` / `post-start.sh` compatible with the new stage layout

**Docker build verification — required before merge** (the proposal session had no docker socket, so these must be run on a host with Docker):

- [ ] `docker compose build backend` uses the `runtime` target
- [ ] `docker run --rm rag-challenge-backend which git` **fails** (git absent from production image)
- [ ] `docker run --rm rag-challenge-backend which node` **fails** (node absent from production image)
- [ ] `docker compose up backend postgres sqlserver` → `GET /api/v1/health/live` returns 200
- [ ] `docker compose exec backend id` → shows `uid=1000(appuser)` (non-root in prod)
- [ ] `docker compose -f docker-compose.yml -f .devcontainer/docker-compose.override.yml build backend` builds the `devcontainer` target
- [ ] Inside the rebuilt devcontainer: `which git` succeeds, `which node` succeeds, `id` still shows `appuser`
- [ ] Inside the rebuilt devcontainer: `cd /app && pytest tests/ -v` → 470/470 still passing

See [`openspec/changes/decouple-devcontainer-image/tasks.md`](../tree/chore/decouple-devcontainer-image/openspec/changes/decouple-devcontainer-image/tasks.md) §5 and §6 for the full checklist.

## Files changed

- `backend/Dockerfile` — split into `runtime` and `devcontainer` stages
- `.devcontainer/docker-compose.override.yml` — adds `build.target: devcontainer`
- `backend/app/api/v1/models.py` — Pydantic v2 `ConfigDict` migration (bonus fix)
- `CHANGELOG.md` — `[Unreleased]` entries under `Changed`, `Security`, `Fixed`
- `docs/conversation_log.md` — Session 20
- `openspec/changes/decouple-devcontainer-image/` — proposal, design, tasks

## Rollback

Single-branch revert. Change is infra-only; no database, data, or API behavior modified.