### PR TITLE
feat: seed initial dataset with Euro 2024 + WC 2022 finals (closes pipeline gap)

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -81,25 +81,6 @@ if is_host_reachable(PG_HOST, 5432):
                 schema_file = REPO_ROOT / "infra/docker/postgres/initdb/02-schema.sql"
                 if schema_file.exists():
                     cur.execute(schema_file.read_text(encoding="utf-8"))
-
-                # Seed row for smoke tests
-                cur.execute("""
-                    INSERT INTO matches (
-                        match_id, match_date,
-                        competition_id, competition_country, competition_name,
-                        season_id, season_name,
-                        home_team_id, home_team_name, home_team_gender, home_team_country,
-                        away_team_id, away_team_name, away_team_gender, away_team_country,
-                        home_score, away_score, result, match_week, json_
-                    )
-                    SELECT
-                        900001, DATE '2024-07-14',
-                        1, 'Europe', 'UEFA Euro', 1, '2024',
-                        100, 'Spain', 'male', 'Spain',
-                        200, 'England', 'male', 'England',
-                        2, 1, 'home', 1, '{"seed": true}'
-                    WHERE NOT EXISTS (SELECT 1 FROM matches WHERE match_id = 900001)
-                """)
         print("  PostgreSQL bootstrap done.")
 else:
     print("  PostgreSQL not reachable — skipping.")
@@ -126,32 +107,21 @@ if is_host_reachable(SQL_HOST, 1433):
             schema_sql = (REPO_ROOT / "infra/docker/sqlserver/initdb/01-schema.sql").read_text(encoding="utf-8")
             for batch in split_sqlserver_batches(schema_sql):
                 cur.execute(batch)
-
-            # Seed row for smoke tests
-            cur.execute("""
-                IF NOT EXISTS (SELECT 1 FROM matches WHERE match_id = 900001)
-                BEGIN
-                    INSERT INTO matches (
-                        match_id, match_date,
-                        competition_id, competition_country, competition_name,
-                        season_id, season_name,
-                        home_team_id, home_team_name, home_team_gender, home_team_country,
-                        away_team_id, away_team_name, away_team_gender, away_team_country,
-                        home_score, away_score, result, match_week, json_
-                    ) VALUES (
-                        900001, '2024-07-14',
-                        1, 'Europe', 'UEFA Euro', 1, '2024',
-                        100, 'Spain', 'male', 'Spain',
-                        200, 'England', 'male', 'England',
-                        2, 1, 'home', 1, '{"seed": true}'
-                    )
-                END
-            """)
         print("  SQL Server bootstrap done.")
 else:
     print("  SQL Server not reachable — skipping.")
 
 print("[post-create] Database bootstrap completed.")
 PY
+
+# ── 3. Seed dataset (idempotent, no API key required) ────────────────
+echo "[post-create] Loading seed dataset (Euro 2024 + WC 2022 finals)..."
+(
+    cd /app && python -m scripts.seed_load --source both
+) || {
+    echo "  [warn] Seed load failed — dashboard will be empty on first open."
+    echo "  [warn] You can retry with: make seed"
+    echo "  [warn] Or: cd /app && python -m scripts.seed_load --source both"
+}
 
 echo "[post-create] Done."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- **ingestion**: New **summary generation** pipeline stage. `IngestionService.run_generate_summaries_job()` reads rows from `events_details__quarter_minute` / `events_details__15secs_agg` where `summary IS NULL`, builds a prompt per 15-second bucket from `backend/app/services/prompts/event_summary.md`, calls `OpenAIAdapter.create_chat_completion()` and writes the response back. This closes a critical gap: the aggregate stage wrote `summary = NULL` and the embeddings stage filtered `WHERE summary IS NOT NULL`, so embeddings were never created out of the box.
+- **api**: `POST /api/v1/ingestion/summaries/generate` — dedicated endpoint for the new stage.
+- **api**: `POST /api/v1/ingestion/full-pipeline` — orchestrator that runs all 5 stages (`download → load → aggregate → summaries → embeddings`) sequentially in a single background job. Aborts on any stage failure.
+- **scripts**: `backend/scripts/seed_load.py` — dev-path loader that downloads a pre-computed seed dataset from a GitHub Release, verifies sha256 per file, and populates both PostgreSQL and SQL Server **without requiring an OpenAI key**. Idempotent: skips if the seed matches are already present.
+- **scripts**: `backend/scripts/seed_build.py` — maintainer-only script to export the seed dataset to a tarball for publication as a GitHub Release asset. Requires `OPENAI_KEY` and ~$0.30 of OpenAI budget (~5,000 summaries + embeddings for both matches).
+- **seed dataset**: Two canonical finals pre-configured as the seed: Euro 2024 Final (Spain 2-1 England, `match_id=3943043`) and FIFA World Cup 2022 Final (Argentina 3-3 France, `match_id=3869685`). Raw StatsBomb JSON is downloaded on demand and not committed to the repo (CC BY-NC-SA 4.0).
+- **devcontainer**: `.devcontainer/post-create.sh` now calls `scripts.seed_load` on first open so the dashboard is populated automatically.
+- **docs**: `data/seed/README.md` documenting the seed dataset, regeneration process, and licensing.
+- **docs**: `docs/getting-started.md` has a new "First run — seed dataset" section.
+- **tooling**: Root-level `Makefile` with `seed`, `seed-force`, `seed-postgres`, `seed-sqlserver`, `test`, `lint`, `format` targets.
+- **tests**: 60+ new unit tests across `test_summary_generation.py`, `test_full_pipeline_orchestrator.py`, `test_seed_build.py`, `test_seed_load.py`, plus 13 new API tests in `test_ingestion.py`.
+
+### Removed
+- **devcontainer**: The synthetic `match_id=900001` placeholder row in `.devcontainer/post-create.sh` is gone. The real seed dataset replaces it.
+
 ### Changed
 - **infra**: Split `backend/Dockerfile` into two stages — `runtime` (production) and `devcontainer` (dev only). The production image no longer carries `git`, `nodejs`, `gnupg2`, `apt-transport-https`, `openssh-client`, `less`, or `procps`. Those tools are layered on in the `devcontainer` stage, which is selected via `build.target: devcontainer` in `.devcontainer/docker-compose.override.yml` and is never built by plain `docker compose up`.
 - **infra**: Production backend container now runs as non-root `appuser` (UID 1000) by default — previously only the devcontainer enforced this.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+# RAG-Challenge — developer convenience targets
+#
+# Run from the repo root. Most targets expect the docker-compose stack to
+# be up (see README.md / docs/getting-started.md). Inside the devcontainer
+# you can also run `cd backend && python -m scripts.<name>` directly.
+
+.PHONY: help seed seed-force seed-postgres seed-sqlserver test lint format
+
+help:
+	@echo "Available targets:"
+	@echo "  seed             Load pre-computed seed dataset (Euro 2024 + WC 2022 finals) into both DBs"
+	@echo "  seed-force       Re-load seed even if already present"
+	@echo "  seed-postgres    Load seed into Postgres only"
+	@echo "  seed-sqlserver   Load seed into SQL Server only"
+	@echo "  test             Run backend pytest suite"
+	@echo "  lint             Ruff lint check on backend/app"
+	@echo "  format           Ruff format on backend/app"
+
+seed:
+	cd backend && python -m scripts.seed_load --source both
+
+seed-force:
+	cd backend && python -m scripts.seed_load --source both --force
+
+seed-postgres:
+	cd backend && python -m scripts.seed_load --source postgres
+
+seed-sqlserver:
+	cd backend && python -m scripts.seed_load --source sqlserver
+
+test:
+	cd backend && pytest tests/ -v
+
+lint:
+	ruff check backend/app
+
+format:
+	ruff format backend/app

--- a/backend/app/api/v1/ingestion.py
+++ b/backend/app/api/v1/ingestion.py
@@ -109,6 +109,40 @@ class EmbeddingsRebuildRequest(BaseModel):
         return normalize_source(value)
 
 
+class SummariesGenerateRequest(BaseModel):
+    source: str = "postgres"
+    match_ids: list[int] = Field(default_factory=list)
+    language: str = "english"
+
+    @field_validator("source")
+    @classmethod
+    def validate_source(cls, value: str) -> str:
+        return normalize_source(value)
+
+
+class FullPipelineRequest(BaseModel):
+    source: str = "postgres"
+    match_ids: list[int] = Field(default_factory=list)
+    competition_id: int | None = None
+    season_id: int | None = None
+    datasets: list[str] = Field(
+        default_factory=lambda: ["matches", "lineups", "events"]
+    )
+    language: str = "english"
+    embedding_models: list[str] | None = None
+    overwrite: bool = False
+
+    @field_validator("source")
+    @classmethod
+    def validate_source(cls, value: str) -> str:
+        return normalize_source(value)
+
+    @field_validator("datasets")
+    @classmethod
+    def validate_datasets(cls, values: list[str]) -> list[str]:
+        return _normalize_datasets(values)
+
+
 def _create_background_job(
     background_tasks: BackgroundTasks,
     *,
@@ -237,6 +271,56 @@ async def start_rebuild_embeddings_job(
         payload=payload,
         source=request.source,
         runner=service.run_rebuild_embeddings_job,
+    )
+
+
+@router.post(
+    "/ingestion/summaries/generate",
+    response_model=JobCreateResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Create summary generation job",
+)
+async def start_generate_summaries_job(
+    request: SummariesGenerateRequest,
+    background_tasks: BackgroundTasks,
+    service: IngestionSvc,
+) -> JobCreateResponse:
+    payload = request.model_dump()
+    return _create_background_job(
+        background_tasks,
+        job_type="summaries_generate",
+        payload=payload,
+        source=request.source,
+        runner=service.run_generate_summaries_job,
+    )
+
+
+@router.post(
+    "/ingestion/full-pipeline",
+    response_model=JobCreateResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Run full ingestion pipeline (download→load→aggregate→summaries→embeddings)",
+)
+async def start_full_pipeline_job(
+    request: FullPipelineRequest,
+    background_tasks: BackgroundTasks,
+    service: IngestionSvc,
+) -> JobCreateResponse:
+    if not request.match_ids and (
+        request.competition_id is None or request.season_id is None
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Provide match_ids or both competition_id and season_id",
+        )
+
+    payload = request.model_dump()
+    return _create_background_job(
+        background_tasks,
+        job_type="full_pipeline",
+        payload=payload,
+        source=request.source,
+        runner=service.run_full_pipeline_job,
     )
 
 

--- a/backend/app/services/ingestion_service.py
+++ b/backend/app/services/ingestion_service.py
@@ -26,6 +26,21 @@ class IngestionService:
         self.settings = get_settings()
         self.statsbomb = statsbomb if statsbomb is not None else StatsBombService()
         self.local_folder = Path(self.settings.repository.local_folder)
+        self._prompt_template_cache: Optional[str] = None
+
+    def _load_prompt_template(self) -> str:
+        """Load and cache the event-summary prompt template from disk.
+
+        The template lives at ``app/services/prompts/event_summary.md`` and uses
+        ``str.format()`` placeholders. It is loaded once and memoized on the
+        service instance so repeated summary generation does not hit the
+        filesystem.
+        """
+        if self._prompt_template_cache is not None:
+            return self._prompt_template_cache
+        template_path = Path(__file__).resolve().parent / "prompts" / "event_summary.md"
+        self._prompt_template_cache = template_path.read_text(encoding="utf-8")
+        return self._prompt_template_cache
 
     @staticmethod
     def _safe_unlink(path: Path) -> bool:
@@ -487,6 +502,298 @@ class IngestionService:
                 "SELECT id, summary FROM events_details__15secs_agg WHERE summary IS NOT NULL ORDER BY id"
             )
         return [(int(r[0]), r[1]) for r in cur.fetchall()]
+
+    def _fetch_aggregation_rows_for_summary(
+        self, conn, source: str, match_ids: list[int]
+    ) -> list[tuple[int, int, int, int, str]]:
+        """Fetch rows from the aggregation table whose ``summary`` is NULL.
+
+        Returns a list of tuples ``(id, period, minute, quarter_minute,
+        events_json)`` ready to be fed to the prompt template. Only rows with
+        ``summary IS NULL`` are returned so the job is resumable — re-running
+        it after a partial failure only processes the remaining rows.
+
+        Note: ``match_id`` is not returned here to keep the tuple shape small
+        and stable. Callers that need it should fetch it via
+        ``_fetch_match_id_by_row_id`` or include it in a custom query.
+        """
+        cur = conn.cursor()
+        if source == "postgres":
+            if match_ids:
+                cur.execute(
+                    """
+                    SELECT id, period, minute, quarter_minute, json_
+                    FROM events_details__quarter_minute
+                    WHERE summary IS NULL AND match_id = ANY(%s)
+                    ORDER BY id
+                    """,
+                    (match_ids,),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT id, period, minute, quarter_minute, json_
+                    FROM events_details__quarter_minute
+                    WHERE summary IS NULL
+                    ORDER BY id
+                    """
+                )
+            return [
+                (int(r[0]), int(r[1] or 0), int(r[2] or 0), int(r[3] or 0), r[4] or "")
+                for r in cur.fetchall()
+            ]
+
+        # SQL Server
+        if match_ids:
+            placeholders = ",".join("?" for _ in match_ids)
+            cur.execute(
+                f"""
+                SELECT id, period, minute, _15secs, json_
+                FROM events_details__15secs_agg
+                WHERE summary IS NULL AND match_id IN ({placeholders})
+                ORDER BY id
+                """,
+                match_ids,
+            )
+        else:
+            cur.execute(
+                """
+                SELECT id, period, minute, _15secs, json_
+                FROM events_details__15secs_agg
+                WHERE summary IS NULL
+                ORDER BY id
+                """
+            )
+        return [
+            (int(r[0]), int(r[1] or 0), int(r[2] or 0), int(r[3] or 0), r[4] or "")
+            for r in cur.fetchall()
+        ]
+
+    def _update_summary_for_row(
+        self, conn, source: str, row_id: int, summary: str
+    ) -> None:
+        """Write a generated summary back to the aggregation table."""
+        cur = conn.cursor()
+        if source == "postgres":
+            cur.execute(
+                "UPDATE events_details__quarter_minute SET summary = %s WHERE id = %s",
+                (summary, row_id),
+            )
+            return
+        cur.execute(
+            "UPDATE events_details__15secs_agg SET summary = ? WHERE id = ?",
+            (summary, row_id),
+        )
+
+    def run_full_pipeline_job(self, job_id: str, payload: dict[str, Any]) -> None:
+        """Orchestrate the full ingestion pipeline as a single job.
+
+        Runs the 5 stages in order:
+        ``download → load → aggregate → summaries → embeddings``.
+
+        Each stage is invoked with the orchestrator's ``job_id`` so its
+        existing ``JobService.update()`` / ``complete()`` / ``fail()``
+        calls feed progress into the same job record. Between stages, the
+        orchestrator re-sets status to ``running`` (overriding the
+        ``success`` set by the previous stage's ``complete`` call) and
+        checks for ``error`` status to abort early.
+
+        If any stage raises, the orchestrator marks the job as failed and
+        does NOT run subsequent stages.
+        """
+        stages = [
+            ("download", self.run_download_job),
+            ("load", self.run_load_job),
+            ("aggregate", self.run_aggregate_job),
+            ("summaries", self.run_generate_summaries_job),
+            ("embeddings", self.run_rebuild_embeddings_job),
+        ]
+        try:
+            JobService.update(
+                job_id,
+                status="running",
+                total=len(stages),
+                message="Running full pipeline",
+            )
+            for idx, (stage_name, runner) in enumerate(stages, start=1):
+                JobService.log(job_id, f"$ pipeline stage {stage_name} starting")
+                try:
+                    runner(job_id, payload)
+                except Exception as e:
+                    JobService.fail(job_id, f"{stage_name} raised: {e}")
+                    return
+                current = JobService.get(job_id)
+                if current and current.get("status") == "error":
+                    return  # sub-stage already called fail
+                JobService.update(
+                    job_id,
+                    status="running",
+                    progress=idx,
+                    message=f"Stage {stage_name} completed",
+                )
+            JobService.complete(job_id, {"stages_completed": len(stages)})
+        except Exception as e:
+            JobService.fail(job_id, str(e))
+
+    def _fetch_match_info_for_prompt(
+        self, conn, source: str, match_ids: list[int]
+    ) -> dict[int, dict[str, Any]]:
+        """Fetch minimal match metadata needed to build the summary prompt.
+
+        Returns a dict keyed by ``match_id`` with ``competition_name``,
+        ``match_date``, ``home_team`` and ``away_team`` strings. Missing
+        match_ids simply do not appear in the result.
+        """
+        if not match_ids:
+            return {}
+        cur = conn.cursor()
+        if source == "postgres":
+            cur.execute(
+                """
+                SELECT match_id, competition_name, match_date, home_team_name, away_team_name
+                FROM matches
+                WHERE match_id = ANY(%s)
+                """,
+                (match_ids,),
+            )
+        else:
+            placeholders = ",".join("?" for _ in match_ids)
+            cur.execute(
+                f"""
+                SELECT match_id, competition_name, match_date, home_team_name, away_team_name
+                FROM matches
+                WHERE match_id IN ({placeholders})
+                """,
+                match_ids,
+            )
+        result: dict[int, dict[str, Any]] = {}
+        for row in cur.fetchall():
+            result[int(row[0])] = {
+                "competition_name": row[1] or "",
+                "match_date": str(row[2]) if row[2] is not None else "",
+                "home_team": row[3] or "",
+                "away_team": row[4] or "",
+            }
+        return result
+
+    def run_generate_summaries_job(self, job_id: str, payload: dict[str, Any]) -> None:
+        """Populate ``summary`` for aggregation rows by calling the chat model.
+
+        For each row in the aggregation table whose ``summary`` is NULL, build
+        a prompt from the event-summary template, call
+        ``OpenAIAdapter.create_chat_completion()``, strip the response, and
+        UPDATE the row. Empty event buckets are skipped. Individual row
+        failures are logged but do NOT abort the whole job — the job reports
+        partial success via its ``result`` payload.
+        """
+        source = normalize_source(payload.get("source", "postgres"))
+        match_ids = [int(v) for v in (payload.get("match_ids") or [])]
+        language = payload.get("language") or "english"
+        try:
+            JobService.update(
+                job_id,
+                status="running",
+                message=f"Generating summaries in {source}",
+            )
+            JobService.log(job_id, f"$ connect --source {source}")
+            if match_ids:
+                JobService.log(
+                    job_id,
+                    "$ summaries --match-ids " + ",".join(map(str, match_ids)),
+                )
+            else:
+                JobService.log(job_id, "$ summaries --all-matches")
+
+            template = self._load_prompt_template()
+            adapter = OpenAIAdapter()
+            updated = 0
+            skipped = 0
+            errored = 0
+            with self._get_connection(source) as conn:
+                match_info = self._fetch_match_info_for_prompt(conn, source, match_ids)
+                rows = self._fetch_aggregation_rows_for_summary(conn, source, match_ids)
+                JobService.update(
+                    job_id,
+                    total=len(rows),
+                    message=f"Preparing {len(rows)} rows for summary generation",
+                )
+                # When the job targets a single match (the seed case), every row
+                # belongs to that match and we can avoid a per-row match_id
+                # lookup. When no match_ids are provided (bulk mode), the
+                # prompt gets empty match_info placeholders — still valid, just
+                # less context-rich.
+                default_info: dict[str, Any] = {}
+                if len(match_ids) == 1:
+                    default_info = match_info.get(match_ids[0], {})
+                for idx, (
+                    row_id,
+                    period,
+                    minute,
+                    quarter_minute,
+                    events_json,
+                ) in enumerate(rows, start=1):
+                    if not events_json:
+                        skipped += 1
+                        JobService.update(
+                            job_id,
+                            progress=idx,
+                            message=f"Skipped row {idx}/{len(rows)} (empty events)",
+                        )
+                        continue
+                    info = default_info
+                    try:
+                        prompt = template.format(
+                            language=language,
+                            competition_name=info.get("competition_name", ""),
+                            match_date=info.get("match_date", ""),
+                            home_team=info.get("home_team", ""),
+                            away_team=info.get("away_team", ""),
+                            period=period,
+                            minute=minute,
+                            quarter_minute=quarter_minute,
+                            events_json=events_json,
+                        )
+                        response = adapter.create_chat_completion(
+                            messages=[
+                                {
+                                    "role": "system",
+                                    "content": (
+                                        "You are a football commentator producing "
+                                        "factual, concise narration from event data."
+                                    ),
+                                },
+                                {"role": "user", "content": prompt},
+                            ],
+                            temperature=0.2,
+                            max_tokens=200,
+                        )
+                        summary = (response or "").strip()
+                        if summary:
+                            self._update_summary_for_row(conn, source, row_id, summary)
+                            updated += 1
+                    except Exception as e:
+                        errored += 1
+                        JobService.log(job_id, f"ERROR row {row_id}: {str(e)[:200]}")
+                    if idx % 25 == 0 or idx == len(rows):
+                        JobService.log(
+                            job_id, f"$ summaries progress {idx}/{len(rows)}"
+                        )
+                    JobService.update(
+                        job_id,
+                        progress=idx,
+                        message=f"Row {idx}/{len(rows)}",
+                    )
+            JobService.complete(
+                job_id,
+                {
+                    "updated_rows": updated,
+                    "skipped_rows": skipped,
+                    "errored_rows": errored,
+                    "source": source,
+                },
+            )
+        except Exception as e:
+            JobService.fail(job_id, str(e))
 
     def _load_matches(self, conn, source: str, match_ids: list[int]) -> dict[str, int]:
         inserted = 0

--- a/backend/app/services/prompts/__init__.py
+++ b/backend/app/services/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Prompt templates for LLM interactions (summaries, translation, etc.)."""

--- a/backend/app/services/prompts/event_summary.md
+++ b/backend/app/services/prompts/event_summary.md
@@ -1,0 +1,22 @@
+You are a football commentator producing factual, concise narration from
+StatsBomb event data. You will receive raw JSON events from a single 15-second
+window of a match and must write a short narrative description in {language}.
+
+Match context:
+- Competition: {competition_name}
+- Date: {match_date}
+- Teams: {home_team} vs {away_team}
+
+Window:
+- Period: {period}
+- Minute: {minute}
+- 15-second bucket: {quarter_minute} (1 = seconds 0-14, 2 = seconds 15-29, 3 = seconds 30-44, 4 = seconds 45-59)
+
+Raw events (concatenated JSON objects separated by commas):
+{events_json}
+
+Write a 1 to 3 sentence narration in {language} describing what happened in this
+window. Focus on facts: who has the ball, what they did, where the play went,
+any shots, fouls, or set pieces. Do NOT invent names, scores, or outcomes not
+present in the events. Do NOT add markdown, headers, bullet points, or
+framing phrases like "In this window...". Respond with the narration only.

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -4,7 +4,7 @@ asyncio_mode = auto
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = -v --tb=short
+addopts = -v --tb=short -m "not integration"
 markers =
     integration: marks tests that require a live database (deselect with -m "not integration")
     unit: marks pure unit tests (no external dependencies)

--- a/backend/scripts/__init__.py
+++ b/backend/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Maintenance scripts for RAG-Challenge (seed build, seed load, etc.).
+
+These are NOT part of the shipped FastAPI application — they import from
+``app`` but run as standalone CLI tools via ``python -m scripts.<name>``.
+"""

--- a/backend/scripts/seed_build.py
+++ b/backend/scripts/seed_build.py
@@ -1,0 +1,331 @@
+"""Maintainer-only script to build the seed dataset tarball.
+
+This script exports the two seed matches (Euro 2024 Final + World Cup 2022
+Final) into a tarball that can be published as a GitHub Release asset so
+new developers don't need an OpenAI key on first run.
+
+**Requires:** `OPENAI_KEY` in `.env` or `.env.docker`, a running Docker
+stack (postgres + sqlserver + backend), and ~$0.50 of OpenAI budget.
+
+Flow:
+    1. Validate OPENAI_KEY is set.
+    2. POST /ingestion/full-pipeline for both match_ids (one job per match
+       to get per-match progress).
+    3. Poll job status until success or failure.
+    4. Read matches + aggregation rows directly from Postgres.
+    5. Serialize to ``seed/v1/<match_id>/`` directory with:
+       - match.json   (raw StatsBomb row)
+       - events.json  (raw StatsBomb events)
+       - summaries.jsonl  (one {row_id, summary} per line)
+       - embeddings_t3_small.jsonl  (one {row_id, vector} per line)
+    6. Write manifest.json with sha256 checksums.
+    7. Create seed-v1.tar.gz.
+    8. Print upload instructions.
+
+Usage:
+    python -m scripts.seed_build --i-have-budget --output ./seed-v1.tar.gz
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import tarfile
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import psycopg2
+
+SEED_MATCH_IDS: dict[int, dict[str, Any]] = {
+    3943043: {
+        "label": "Euro 2024 Final (Spain 2-1 England)",
+        "competition_id": 55,
+        "season_id": 282,
+    },
+    3869685: {
+        "label": "World Cup 2022 Final (Argentina 3-3 France, pens 4-2)",
+        "competition_id": 43,
+        "season_id": 106,
+    },
+}
+
+SEED_VERSION = "v1"
+EMBEDDING_MODEL = "text-embedding-3-small"
+BACKEND_URL_DEFAULT = "http://localhost:8000"
+
+
+def _require_api_key() -> None:
+    """Fail fast if no OpenAI key is configured."""
+    key = os.environ.get("OPENAI_KEY") or os.environ.get("OPENAI_API_KEY")
+    if not key:
+        sys.stderr.write(
+            "ERROR: OPENAI_KEY not set. This script makes paid API calls.\n"
+            "Set it in backend/.env or .env.docker (both gitignored) or "
+            "export it in the shell before running.\n"
+        )
+        sys.exit(2)
+
+
+def _run_full_pipeline(backend_url: str, match_id: int, meta: dict[str, Any]) -> None:
+    """POST /ingestion/full-pipeline for a single match and wait for success."""
+    payload = {
+        "source": "postgres",
+        "match_ids": [match_id],
+        "competition_id": meta["competition_id"],
+        "season_id": meta["season_id"],
+        "datasets": ["matches", "lineups", "events"],
+        "embedding_models": [EMBEDDING_MODEL],
+    }
+    print(f"[build] Starting full pipeline for match {match_id} ({meta['label']})")
+    with httpx.Client(base_url=backend_url, timeout=60.0) as client:
+        resp = client.post("/api/v1/ingestion/full-pipeline", json=payload)
+        resp.raise_for_status()
+        job_id = resp.json()["job_id"]
+        print(f"[build]   job_id={job_id}")
+
+        while True:
+            time.sleep(5)
+            status_resp = client.get(f"/api/v1/ingestion/jobs/{job_id}")
+            status_resp.raise_for_status()
+            job = status_resp.json()
+            print(
+                f"[build]   status={job['status']} "
+                f"progress={job['progress']}/{job['total']} "
+                f"message={job['message']}"
+            )
+            if job["status"] == "success":
+                return
+            if job["status"] == "error":
+                sys.stderr.write(
+                    f"ERROR: pipeline failed for {match_id}: {job.get('error')}\n"
+                )
+                sys.exit(3)
+
+
+def _export_match(conn, match_id: int, seed_dir: Path) -> dict[str, str]:
+    """Read a single match from Postgres and write seed files for it.
+
+    Returns a dict of filename -> sha256 for the manifest.
+    """
+    match_dir = seed_dir / str(match_id)
+    match_dir.mkdir(parents=True, exist_ok=True)
+    checksums: dict[str, str] = {}
+
+    cur = conn.cursor()
+
+    # Raw match row from the matches table
+    cur.execute("SELECT json_ FROM matches WHERE match_id = %s", (match_id,))
+    row = cur.fetchone()
+    if not row:
+        raise RuntimeError(f"Match {match_id} not in database after pipeline ran")
+    match_json = row[0]
+    if isinstance(match_json, str):
+        match_json = json.loads(match_json)
+    (match_dir / "match.json").write_text(
+        json.dumps(match_json, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    # Raw events
+    cur.execute("SELECT json_ FROM events WHERE match_id = %s", (match_id,))
+    row = cur.fetchone()
+    if not row:
+        raise RuntimeError(f"Events for {match_id} not in database")
+    events_json = row[0]
+    if isinstance(events_json, str):
+        events_json = json.loads(events_json)
+    (match_dir / "events.json").write_text(
+        json.dumps(events_json, ensure_ascii=False), encoding="utf-8"
+    )
+
+    # Summaries — one JSONL row per aggregation bucket
+    cur.execute(
+        """
+        SELECT id, match_id, period, minute, quarter_minute, summary
+        FROM events_details__quarter_minute
+        WHERE match_id = %s AND summary IS NOT NULL
+        ORDER BY id
+        """,
+        (match_id,),
+    )
+    summaries_path = match_dir / "summaries.jsonl"
+    with summaries_path.open("w", encoding="utf-8") as f:
+        for r in cur.fetchall():
+            f.write(
+                json.dumps(
+                    {
+                        "row_id": int(r[0]),
+                        "match_id": int(r[1]),
+                        "period": int(r[2] or 0),
+                        "minute": int(r[3] or 0),
+                        "quarter_minute": int(r[4] or 0),
+                        "summary": r[5],
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+
+    # Embeddings — one JSONL row per bucket with the t3_small vector
+    cur.execute(
+        """
+        SELECT id, summary_embedding_t3_small::text
+        FROM events_details__quarter_minute
+        WHERE match_id = %s AND summary_embedding_t3_small IS NOT NULL
+        ORDER BY id
+        """,
+        (match_id,),
+    )
+    embeddings_path = match_dir / "embeddings_t3_small.jsonl"
+    with embeddings_path.open("w", encoding="utf-8") as f:
+        for r in cur.fetchall():
+            # pgvector returns "[0.1, 0.2, ...]" string; parse to list for storage
+            vector_str = r[1]
+            vector = json.loads(vector_str)
+            f.write(json.dumps({"row_id": int(r[0]), "vector": vector}) + "\n")
+
+    # Compute sha256 for each file
+    for name in (
+        "match.json",
+        "events.json",
+        "summaries.jsonl",
+        "embeddings_t3_small.jsonl",
+    ):
+        path = match_dir / name
+        sha = hashlib.sha256(path.read_bytes()).hexdigest()
+        checksums[f"{match_id}/{name}"] = sha
+        print(f"[build]     {match_id}/{name}  sha256={sha[:12]}...")
+
+    return checksums
+
+
+def _connect_postgres() -> Any:
+    """Open a psycopg2 connection using env vars."""
+    return psycopg2.connect(
+        host=os.environ.get("POSTGRES_HOST", "localhost"),
+        port=int(os.environ.get("POSTGRES_PORT", "5432")),
+        database=os.environ.get("POSTGRES_DB", "rag_challenge"),
+        user=os.environ.get("POSTGRES_USER", "postgres"),
+        password=os.environ.get("POSTGRES_PASSWORD", "postgres_local_pwd"),
+    )
+
+
+def build_seed(
+    output: Path, backend_url: str, match_ids: list[int], skip_pipeline: bool
+) -> None:
+    """Main entry point for building the seed tarball."""
+    if not skip_pipeline:
+        _require_api_key()
+        for match_id in match_ids:
+            _run_full_pipeline(backend_url, match_id, SEED_MATCH_IDS[match_id])
+
+    work_dir = Path.cwd() / ".seed-build-tmp"
+    seed_root = work_dir / "seed" / SEED_VERSION
+    if work_dir.exists():
+        import shutil
+
+        shutil.rmtree(work_dir)
+    seed_root.mkdir(parents=True)
+
+    all_checksums: dict[str, str] = {}
+    print(f"[build] Exporting {len(match_ids)} match(es) from Postgres")
+    with _connect_postgres() as conn:
+        for match_id in match_ids:
+            all_checksums.update(_export_match(conn, match_id, seed_root))
+
+    # Manifest
+    manifest = {
+        "version": SEED_VERSION,
+        "embedding_model": EMBEDDING_MODEL,
+        "matches": [
+            {
+                "match_id": mid,
+                "label": SEED_MATCH_IDS[mid]["label"],
+                "competition_id": SEED_MATCH_IDS[mid]["competition_id"],
+                "season_id": SEED_MATCH_IDS[mid]["season_id"],
+            }
+            for mid in match_ids
+        ],
+        "files": all_checksums,
+    }
+    manifest_path = seed_root / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    # Tar it up
+    print(f"[build] Creating {output}")
+    with tarfile.open(output, "w:gz") as tar:
+        tar.add(work_dir / "seed", arcname="seed")
+
+    tar_sha = hashlib.sha256(output.read_bytes()).hexdigest()
+    print(f"[build] Done: {output}")
+    print(f"[build] sha256: {tar_sha}")
+    print("[build]")
+    print("[build] Next steps:")
+    print("[build]   1. Review the tarball contents:")
+    print(f"[build]      tar tzf {output} | head -20")
+    print("[build]   2. Upload to GitHub Release:")
+    print(f"[build]      gh release create seed/{SEED_VERSION} {output} \\")
+    print(f"[build]          --title 'Seed dataset {SEED_VERSION}' \\")
+    print(
+        "[build]          --notes 'Pre-computed summaries and embeddings for "
+        "Euro 2024 + WC 2022 finals.'"
+    )
+    print("[build]   3. Update SEED_SHA256 in scripts/seed_load.py if needed.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build the seed dataset tarball (maintainer-only)"
+    )
+    parser.add_argument(
+        "--i-have-budget",
+        action="store_true",
+        help="Explicit flag: you acknowledge this runs paid OpenAI calls.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("./seed-v1.tar.gz"),
+        help="Output tarball path (default: ./seed-v1.tar.gz)",
+    )
+    parser.add_argument(
+        "--backend-url",
+        default=BACKEND_URL_DEFAULT,
+        help=f"Backend base URL (default: {BACKEND_URL_DEFAULT})",
+    )
+    parser.add_argument(
+        "--match-ids",
+        default=",".join(str(m) for m in SEED_MATCH_IDS),
+        help="Comma-separated list of match_ids to seed",
+    )
+    parser.add_argument(
+        "--skip-pipeline",
+        action="store_true",
+        help="Skip the full-pipeline step (assume data is already in Postgres)",
+    )
+    args = parser.parse_args()
+
+    if not args.i_have_budget and not args.skip_pipeline:
+        sys.stderr.write(
+            "ERROR: pass --i-have-budget to acknowledge this runs paid "
+            "OpenAI calls, or --skip-pipeline if data is already in Postgres.\n"
+        )
+        sys.exit(1)
+
+    match_ids = [int(m) for m in args.match_ids.split(",") if m.strip()]
+    unknown = [m for m in match_ids if m not in SEED_MATCH_IDS]
+    if unknown:
+        sys.stderr.write(f"ERROR: unknown match_ids: {unknown}\n")
+        sys.exit(1)
+
+    build_seed(args.output, args.backend_url, match_ids, args.skip_pipeline)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/seed_load.py
+++ b/backend/scripts/seed_load.py
@@ -1,0 +1,478 @@
+"""Dev-path seed loader: loads pre-computed seed dataset into local DBs.
+
+Runs during ``.devcontainer/post-create.sh`` the first time a developer
+opens the repo in VS Code / Docker. Does NOT call OpenAI — reads
+everything from a GitHub Release tarball cached under
+``~/.cache/rag-challenge-seed/``.
+
+Idempotent: if both seed matches are already present with non-null
+embeddings, exits 0 in ~100 ms without touching files or DB.
+
+Graceful degrade: any failure (network, sha mismatch, DB down) logs a
+clear warning and exits non-zero; the calling post-create script is
+expected to continue anyway so the devcontainer still starts.
+
+Usage:
+    python -m scripts.seed_load                  # both sources
+    python -m scripts.seed_load --source postgres
+    python -m scripts.seed_load --source sqlserver
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterable
+
+SEED_VERSION = "v1"
+SEED_MATCH_IDS = (3943043, 3869685)
+SEED_URL = (
+    "https://github.com/erincon01/RAG-Challenge/releases/download/"
+    f"seed/{SEED_VERSION}/seed-{SEED_VERSION}.tar.gz"
+)
+CACHE_DIR = Path.home() / ".cache" / "rag-challenge-seed"
+TARBALL_NAME = f"seed-{SEED_VERSION}.tar.gz"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency check
+# ---------------------------------------------------------------------------
+
+
+def check_idempotency(source: str) -> bool:
+    """Return True if both seed matches are fully loaded in this source.
+
+    "Fully loaded" means: the ``matches`` table has both match_ids AND
+    the aggregation table has at least one row per match_id with a
+    non-null ``summary_embedding_t3_small`` (postgres) or
+    ``embedding_3_small`` (sqlserver). If so the seed is already there
+    and we can skip everything.
+    """
+    try:
+        with _connect(source) as conn:
+            cur = conn.cursor()
+            placeholders = (
+                "ANY(%s)"
+                if source == "postgres"
+                else "(" + ",".join("?" for _ in SEED_MATCH_IDS) + ")"
+            )
+            params: tuple[Any, ...] = (
+                (list(SEED_MATCH_IDS),) if source == "postgres" else SEED_MATCH_IDS
+            )
+
+            cur.execute(
+                f"SELECT COUNT(*) FROM matches WHERE match_id {'= ANY(%s)' if source == 'postgres' else 'IN ' + placeholders}",
+                params,
+            )
+            row = cur.fetchone()
+            if int(row[0] or 0) < len(SEED_MATCH_IDS):
+                return False
+
+            if source == "postgres":
+                cur.execute(
+                    """
+                    SELECT COUNT(DISTINCT match_id)
+                    FROM events_details__quarter_minute
+                    WHERE match_id = ANY(%s)
+                      AND summary_embedding_t3_small IS NOT NULL
+                    """,
+                    (list(SEED_MATCH_IDS),),
+                )
+            else:
+                qmarks = ",".join("?" for _ in SEED_MATCH_IDS)
+                cur.execute(
+                    f"""
+                    SELECT COUNT(DISTINCT match_id)
+                    FROM events_details__15secs_agg
+                    WHERE match_id IN ({qmarks})
+                      AND embedding_3_small IS NOT NULL
+                    """,
+                    SEED_MATCH_IDS,
+                )
+            row = cur.fetchone()
+            return int(row[0] or 0) >= len(SEED_MATCH_IDS)
+    except Exception as e:
+        print(f"[seed-load] Idempotency check failed for {source}: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Download + verify
+# ---------------------------------------------------------------------------
+
+
+def download_and_extract(cache_dir: Path) -> Path:
+    """Download (if needed) and extract the seed tarball.
+
+    Returns the path to the extracted ``seed/v1/`` directory.
+    Raises on download failure or sha mismatch.
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    tarball_path = cache_dir / TARBALL_NAME
+
+    if not tarball_path.exists():
+        print(f"[seed-load] Downloading {SEED_URL}")
+        try:
+            with urllib.request.urlopen(SEED_URL, timeout=60) as resp:
+                with tarball_path.open("wb") as out:
+                    shutil.copyfileobj(resp, out)
+        except (urllib.error.URLError, urllib.error.HTTPError) as e:
+            raise RuntimeError(f"Download failed: {e}") from e
+
+    extract_dir = cache_dir / SEED_VERSION
+    if extract_dir.exists():
+        shutil.rmtree(extract_dir)
+    extract_dir.mkdir(parents=True)
+
+    with tarfile.open(tarball_path, "r:gz") as tar:
+        tar.extractall(extract_dir, filter="data")
+
+    seed_root = extract_dir / "seed" / SEED_VERSION
+    if not seed_root.exists():
+        raise RuntimeError(f"Unexpected tarball layout — {seed_root} not found")
+
+    manifest_path = seed_root / "manifest.json"
+    if not manifest_path.exists():
+        raise RuntimeError("manifest.json missing from seed tarball")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    for relative_path, expected_sha in manifest.get("files", {}).items():
+        file_path = seed_root / relative_path
+        if not file_path.exists():
+            raise RuntimeError(f"Seed file missing: {relative_path}")
+        actual_sha = hashlib.sha256(file_path.read_bytes()).hexdigest()
+        if actual_sha != expected_sha:
+            raise RuntimeError(
+                f"sha256 mismatch on {relative_path}: "
+                f"expected {expected_sha[:12]}, got {actual_sha[:12]}"
+            )
+
+    print(f"[seed-load] Seed verified: {len(manifest.get('files', {}))} files OK")
+    return seed_root
+
+
+# ---------------------------------------------------------------------------
+# DB connection helpers
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _connect(source: str):
+    """Open a raw connection for postgres or sqlserver using env vars."""
+    conn = None
+    try:
+        if source == "postgres":
+            import psycopg2
+
+            conn = psycopg2.connect(
+                host=os.environ.get("POSTGRES_HOST", "postgres"),
+                port=int(os.environ.get("POSTGRES_PORT", "5432")),
+                database=os.environ.get("POSTGRES_DB", "rag_challenge"),
+                user=os.environ.get("POSTGRES_USER", "postgres"),
+                password=os.environ.get("POSTGRES_PASSWORD", "postgres_local_pwd"),
+            )
+        elif source == "sqlserver":
+            import pyodbc
+
+            conn = pyodbc.connect(
+                "DRIVER={ODBC Driver 18 for SQL Server};"
+                f"SERVER={os.environ.get('SQLSERVER_HOST', 'sqlserver')};"
+                f"DATABASE={os.environ.get('SQLSERVER_DB', 'rag_challenge')};"
+                f"UID={os.environ.get('SQLSERVER_USER', 'sa')};"
+                f"PWD={os.environ.get('SQLSERVER_PASSWORD', 'SqlServer_Local_Pwd123!')};"
+                "TrustServerCertificate=yes;"
+            )
+        else:
+            raise ValueError(f"Unsupported source: {source}")
+        yield conn
+        conn.commit()
+    except Exception:
+        if conn:
+            conn.rollback()
+        raise
+    finally:
+        if conn:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Stage files into the format IngestionService expects
+# ---------------------------------------------------------------------------
+
+
+def _stage_seed_for_ingestion(seed_root: Path, staging_dir: Path) -> list[int]:
+    """Copy tarball files into the layout expected by IngestionService.
+
+    The seed tarball has:
+        seed/v1/<match_id>/match.json       (single match dict)
+        seed/v1/<match_id>/events.json      (list of events)
+
+    IngestionService._iter_matches_from_local reads
+    ``{local_folder}/matches/**/*.json`` expecting a list of dicts.
+    IngestionService._load_events reads
+    ``{local_folder}/events/<match_id>.json`` as a list of events.
+
+    This helper copies+wraps accordingly.
+    """
+    matches_dir = staging_dir / "matches"
+    events_dir = staging_dir / "events"
+    matches_dir.mkdir(parents=True, exist_ok=True)
+    events_dir.mkdir(parents=True, exist_ok=True)
+
+    match_ids: list[int] = []
+    all_matches_list: list[dict[str, Any]] = []
+
+    for match_dir in sorted(seed_root.iterdir()):
+        if not match_dir.is_dir():
+            continue
+        try:
+            match_id = int(match_dir.name)
+        except ValueError:
+            continue
+
+        match_json_path = match_dir / "match.json"
+        events_json_path = match_dir / "events.json"
+        if not match_json_path.exists() or not events_json_path.exists():
+            continue
+
+        with match_json_path.open("r", encoding="utf-8") as f:
+            match_data = json.load(f)
+        all_matches_list.append(match_data)
+
+        shutil.copyfile(events_json_path, events_dir / f"{match_id}.json")
+        match_ids.append(match_id)
+
+    # Single file with all matches so _iter_matches_from_local picks them up
+    (matches_dir / "seed.json").write_text(
+        json.dumps(all_matches_list, ensure_ascii=False), encoding="utf-8"
+    )
+    return sorted(match_ids)
+
+
+# ---------------------------------------------------------------------------
+# Apply summaries + embeddings from JSONL files
+# ---------------------------------------------------------------------------
+
+
+def _iter_jsonl(path: Path) -> Iterable[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+
+
+def _apply_summaries_and_embeddings(
+    conn, source: str, seed_root: Path, match_ids: list[int]
+) -> dict[str, int]:
+    """Update aggregation rows with pre-computed summaries and embeddings.
+
+    Matches seed rows to DB rows by (match_id, period, minute, quarter_minute)
+    because the auto-increment ``id`` will differ between the build machine
+    and the loading machine.
+    """
+    cur = conn.cursor()
+    stats = {"summaries_updated": 0, "embeddings_updated": 0}
+
+    for match_id in match_ids:
+        match_dir = seed_root / str(match_id)
+
+        # Build a (period, minute, quarter_minute) -> DB id lookup for this match
+        if source == "postgres":
+            cur.execute(
+                """
+                SELECT id, period, minute, quarter_minute
+                FROM events_details__quarter_minute
+                WHERE match_id = %s
+                """,
+                (match_id,),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT id, period, minute, _15secs
+                FROM events_details__15secs_agg
+                WHERE match_id = ?
+                """,
+                (match_id,),
+            )
+        id_by_key = {
+            (int(r[1] or 0), int(r[2] or 0), int(r[3] or 0)): int(r[0])
+            for r in cur.fetchall()
+        }
+
+        # Summaries
+        summaries_path = match_dir / "summaries.jsonl"
+        if summaries_path.exists():
+            for rec in _iter_jsonl(summaries_path):
+                key = (
+                    int(rec.get("period") or 0),
+                    int(rec.get("minute") or 0),
+                    int(rec.get("quarter_minute") or 0),
+                )
+                db_id = id_by_key.get(key)
+                if db_id is None:
+                    continue
+                if source == "postgres":
+                    cur.execute(
+                        "UPDATE events_details__quarter_minute SET summary = %s WHERE id = %s",
+                        (rec["summary"], db_id),
+                    )
+                else:
+                    cur.execute(
+                        "UPDATE events_details__15secs_agg SET summary = ? WHERE id = ?",
+                        (rec["summary"], db_id),
+                    )
+                stats["summaries_updated"] += 1
+
+        # Embeddings (t3_small)
+        emb_path = match_dir / "embeddings_t3_small.jsonl"
+        if emb_path.exists():
+            # Embeddings file keys by row_id from the build machine. That id
+            # won't match here; but we exported summaries.jsonl in the same
+            # order, so we can use the matched db_id from the summaries
+            # write-back. For this version we re-match by position within
+            # the match: read both files in parallel.
+            summaries_records = (
+                list(_iter_jsonl(summaries_path)) if summaries_path.exists() else []
+            )
+            embedding_records = list(_iter_jsonl(emb_path))
+            if len(summaries_records) != len(embedding_records):
+                print(
+                    f"[seed-load]   WARN: summaries/embeddings count mismatch "
+                    f"for {match_id}: {len(summaries_records)} vs {len(embedding_records)}"
+                )
+            for s_rec, e_rec in zip(summaries_records, embedding_records):
+                key = (
+                    int(s_rec.get("period") or 0),
+                    int(s_rec.get("minute") or 0),
+                    int(s_rec.get("quarter_minute") or 0),
+                )
+                db_id = id_by_key.get(key)
+                if db_id is None:
+                    continue
+                vector = e_rec["vector"]
+                vector_str = "[" + ",".join(str(v) for v in vector) + "]"
+                if source == "postgres":
+                    cur.execute(
+                        "UPDATE events_details__quarter_minute "
+                        "SET summary_embedding_t3_small = %s::vector, "
+                        "embedding_status = 'done' WHERE id = %s",
+                        (vector_str, db_id),
+                    )
+                else:
+                    cur.execute(
+                        "UPDATE events_details__15secs_agg "
+                        "SET embedding_3_small = CAST(? AS VECTOR(1536)), "
+                        "embedding_status = 'done' WHERE id = ?",
+                        (vector_str, db_id),
+                    )
+                stats["embeddings_updated"] += 1
+
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Main load flow
+# ---------------------------------------------------------------------------
+
+
+def load_into(source: str, seed_root: Path) -> dict[str, int]:
+    """Full load sequence for a single source (postgres or sqlserver)."""
+    print(f"[seed-load] Loading into {source}")
+    # Stage files into the layout IngestionService expects
+    with tempfile.TemporaryDirectory() as tmp:
+        staging_dir = Path(tmp)
+        match_ids = _stage_seed_for_ingestion(seed_root, staging_dir)
+        print(f"[seed-load]   staged match_ids: {match_ids}")
+
+        # Import here to avoid top-level import cost when idempotent short-circuits
+        from app.services.ingestion_service import IngestionService
+
+        service = IngestionService()
+        # Point the service at our temp staging dir for this load
+        service.local_folder = staging_dir
+
+        with _connect(source) as conn:
+            matches_result = service._load_matches(conn, source, match_ids)
+            print(f"[seed-load]   matches: {matches_result}")
+            events_result = service._load_events(conn, source, match_ids)
+            print(f"[seed-load]   events: {events_result}")
+            agg_count = service._build_aggregations(conn, source, match_ids)
+            print(f"[seed-load]   aggregated rows: {agg_count}")
+            stats = _apply_summaries_and_embeddings(conn, source, seed_root, match_ids)
+            print(
+                f"[seed-load]   summaries_updated={stats['summaries_updated']} "
+                f"embeddings_updated={stats['embeddings_updated']}"
+            )
+            return {
+                "match_ids": match_ids,
+                "aggregated_rows": agg_count,
+                **stats,
+            }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Load the pre-computed seed dataset into local DBs"
+    )
+    parser.add_argument(
+        "--source",
+        choices=["postgres", "sqlserver", "both"],
+        default="both",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Reload even if idempotency check passes",
+    )
+    args = parser.parse_args()
+
+    sources = ["postgres", "sqlserver"] if args.source == "both" else [args.source]
+
+    # Idempotency check per source
+    to_load: list[str] = []
+    for src in sources:
+        if args.force:
+            to_load.append(src)
+            continue
+        if check_idempotency(src):
+            print(f"[seed-load] {src}: already seeded, skipping")
+        else:
+            to_load.append(src)
+
+    if not to_load:
+        print("[seed-load] Nothing to do — all sources already seeded")
+        return 0
+
+    # Download + verify seed tarball once
+    try:
+        seed_root = download_and_extract(CACHE_DIR)
+    except Exception as e:
+        print(f"[seed-load] ERROR downloading seed: {e}", file=sys.stderr)
+        return 1
+
+    errors = 0
+    for src in to_load:
+        try:
+            load_into(src, seed_root)
+        except Exception as e:
+            print(f"[seed-load] ERROR loading {src}: {e}", file=sys.stderr)
+            errors += 1
+
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/api/test_ingestion.py
+++ b/backend/tests/api/test_ingestion.py
@@ -10,12 +10,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from tests.conftest import make_mock_match_repo, make_mock_event_repo, make_mock_openai_adapter
+from tests.conftest import (
+    make_mock_match_repo,
+    make_mock_event_repo,
+    make_mock_openai_adapter,
+)
 
 
 @pytest.fixture
 def mock_ingestion_svc():
     from app.services.ingestion_service import IngestionService
+
     svc = MagicMock(spec=IngestionService)
     svc.clear_downloaded_files.return_value = {
         "deleted_count": 0,
@@ -30,12 +35,18 @@ def mock_ingestion_svc():
 def client(mock_ingestion_svc):
     from app.main import app
     from app.core.dependencies import (
-        get_match_repository, get_event_repository, get_ingestion_service,
+        get_match_repository,
+        get_event_repository,
+        get_ingestion_service,
     )
     from app.adapters.openai_client import get_openai_adapter
 
-    app.dependency_overrides[get_match_repository] = lambda source="postgres": make_mock_match_repo()
-    app.dependency_overrides[get_event_repository] = lambda source="postgres": make_mock_event_repo()
+    app.dependency_overrides[get_match_repository] = lambda source="postgres": (
+        make_mock_match_repo()
+    )
+    app.dependency_overrides[get_event_repository] = lambda source="postgres": (
+        make_mock_event_repo()
+    )
     app.dependency_overrides[get_openai_adapter] = lambda: make_mock_openai_adapter()
     app.dependency_overrides[get_ingestion_service] = lambda: mock_ingestion_svc
 
@@ -48,6 +59,7 @@ def client(mock_ingestion_svc):
 # ---------------------------------------------------------------------------
 # POST /ingestion/download
 # ---------------------------------------------------------------------------
+
 
 class TestStartDownloadJob:
     def test_returns_202_with_match_ids(self, client):
@@ -93,6 +105,7 @@ class TestStartDownloadJob:
 # POST /ingestion/download/cleanup
 # ---------------------------------------------------------------------------
 
+
 class TestCleanupDownloadedFiles:
     def test_returns_200_delete_all(self, client, mock_ingestion_svc):
         mock_ingestion_svc.clear_downloaded_files.return_value = {
@@ -134,6 +147,7 @@ class TestCleanupDownloadedFiles:
 # POST /ingestion/load
 # ---------------------------------------------------------------------------
 
+
 class TestStartLoadJob:
     def test_start_load_valid_request_returns_202(self, client):
         response = client.post(
@@ -162,6 +176,7 @@ class TestStartLoadJob:
 # POST /ingestion/aggregate
 # ---------------------------------------------------------------------------
 
+
 class TestStartAggregateJob:
     def test_start_aggregate_valid_request_returns_202(self, client):
         response = client.post(
@@ -182,6 +197,7 @@ class TestStartAggregateJob:
 # ---------------------------------------------------------------------------
 # POST /ingestion/embeddings/rebuild
 # ---------------------------------------------------------------------------
+
 
 class TestStartRebuildEmbeddingsJob:
     def test_start_rebuild_valid_request_returns_202(self, client):
@@ -204,6 +220,7 @@ class TestStartRebuildEmbeddingsJob:
 # GET /ingestion/jobs
 # ---------------------------------------------------------------------------
 
+
 class TestListJobs:
     def test_list_jobs_default_returns_200(self, client):
         response = client.get("/api/v1/ingestion/jobs")
@@ -222,6 +239,7 @@ class TestListJobs:
 # DELETE /ingestion/jobs
 # ---------------------------------------------------------------------------
 
+
 class TestClearJobs:
     def test_clear_jobs_default_returns_200(self, client):
         response = client.delete("/api/v1/ingestion/jobs")
@@ -235,6 +253,7 @@ class TestClearJobs:
 # ---------------------------------------------------------------------------
 # GET /ingestion/jobs/{job_id}
 # ---------------------------------------------------------------------------
+
 
 class TestGetJob:
     def test_returns_404_for_unknown_job(self, client):
@@ -257,12 +276,14 @@ class TestGetJob:
 # These tests FAIL until ingestion.py uses Depends(get_ingestion_service)
 # ---------------------------------------------------------------------------
 
+
 class TestIngestionDependencyInjection:
     @pytest.fixture
     def client_with_override(self):
         from app.main import app
         from app.core.dependencies import (
-            get_match_repository, get_event_repository,
+            get_match_repository,
+            get_event_repository,
             get_ingestion_service,
         )
         from app.adapters.openai_client import get_openai_adapter
@@ -271,9 +292,15 @@ class TestIngestionDependencyInjection:
         mock_svc = MagicMock(spec=IngestionService)
         mock_svc.run_download_job = MagicMock()
 
-        app.dependency_overrides[get_match_repository] = lambda source="postgres": make_mock_match_repo()
-        app.dependency_overrides[get_event_repository] = lambda source="postgres": make_mock_event_repo()
-        app.dependency_overrides[get_openai_adapter] = lambda: make_mock_openai_adapter()
+        app.dependency_overrides[get_match_repository] = lambda source="postgres": (
+            make_mock_match_repo()
+        )
+        app.dependency_overrides[get_event_repository] = lambda source="postgres": (
+            make_mock_event_repo()
+        )
+        app.dependency_overrides[get_openai_adapter] = lambda: (
+            make_mock_openai_adapter()
+        )
         app.dependency_overrides[get_ingestion_service] = lambda: mock_svc
 
         with TestClient(app, raise_server_exceptions=False) as c:
@@ -296,3 +323,131 @@ class TestIngestionDependencyInjection:
             json={"match_ids": [3943043], "datasets": ["matches"]},
         )
         mock_svc.run_download_job.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# POST /ingestion/summaries/generate
+# ---------------------------------------------------------------------------
+
+
+class TestStartGenerateSummariesJob:
+    def test_returns_202_with_valid_payload(self, client):
+        response = client.post(
+            "/api/v1/ingestion/summaries/generate",
+            json={"source": "postgres", "match_ids": [3943043]},
+        )
+        assert response.status_code == 202
+
+    def test_response_has_job_id_and_type(self, client):
+        response = client.post(
+            "/api/v1/ingestion/summaries/generate",
+            json={"source": "postgres", "match_ids": [3943043]},
+        )
+        data = response.json()
+        assert "job_id" in data
+        assert data["type"] == "summaries_generate"
+
+    def test_accepts_unknown_source_passthrough(self, client):
+        """``normalize_source`` passes unknown values through unchanged
+        (see app/core/capabilities.py). Source validation happens later in
+        the service layer when it tries to open a connection. This matches
+        the behavior of /ingestion/load, /aggregate, /embeddings/rebuild."""
+        response = client.post(
+            "/api/v1/ingestion/summaries/generate",
+            json={"source": "mongo", "match_ids": [3943043]},
+        )
+        assert response.status_code == 202
+
+    def test_accepts_sqlserver_source(self, client):
+        response = client.post(
+            "/api/v1/ingestion/summaries/generate",
+            json={"source": "sqlserver", "match_ids": [3943043]},
+        )
+        assert response.status_code == 202
+
+    def test_accepts_language_override(self, client):
+        response = client.post(
+            "/api/v1/ingestion/summaries/generate",
+            json={
+                "source": "postgres",
+                "match_ids": [3943043],
+                "language": "spanish",
+            },
+        )
+        assert response.status_code == 202
+
+    def test_empty_match_ids_allowed_as_bulk_mode(self, client):
+        """Empty match_ids means 'all matches with NULL summary'."""
+        response = client.post(
+            "/api/v1/ingestion/summaries/generate",
+            json={"source": "postgres", "match_ids": []},
+        )
+        assert response.status_code == 202
+
+    def test_calls_service_run_generate_summaries_job(self, mock_ingestion_svc, client):
+        mock_ingestion_svc.run_generate_summaries_job = MagicMock()
+        client.post(
+            "/api/v1/ingestion/summaries/generate",
+            json={"source": "postgres", "match_ids": [3943043]},
+        )
+        mock_ingestion_svc.run_generate_summaries_job.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# POST /ingestion/full-pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestStartFullPipelineJob:
+    def test_returns_202_with_match_ids(self, client):
+        response = client.post(
+            "/api/v1/ingestion/full-pipeline",
+            json={"source": "postgres", "match_ids": [3943043]},
+        )
+        assert response.status_code == 202
+
+    def test_returns_202_with_competition_and_season(self, client):
+        response = client.post(
+            "/api/v1/ingestion/full-pipeline",
+            json={
+                "source": "postgres",
+                "competition_id": 55,
+                "season_id": 282,
+            },
+        )
+        assert response.status_code == 202
+
+    def test_returns_400_when_no_ids_or_competition(self, client):
+        response = client.post(
+            "/api/v1/ingestion/full-pipeline",
+            json={"source": "postgres"},
+        )
+        assert response.status_code == 400
+
+    def test_response_has_job_id_and_type(self, client):
+        response = client.post(
+            "/api/v1/ingestion/full-pipeline",
+            json={"source": "postgres", "match_ids": [3943043]},
+        )
+        data = response.json()
+        assert "job_id" in data
+        assert data["type"] == "full_pipeline"
+
+    def test_calls_service_run_full_pipeline_job(self, mock_ingestion_svc, client):
+        mock_ingestion_svc.run_full_pipeline_job = MagicMock()
+        client.post(
+            "/api/v1/ingestion/full-pipeline",
+            json={"source": "postgres", "match_ids": [3943043]},
+        )
+        mock_ingestion_svc.run_full_pipeline_job.assert_called_once()
+
+    def test_accepts_embedding_models_override(self, client):
+        response = client.post(
+            "/api/v1/ingestion/full-pipeline",
+            json={
+                "source": "postgres",
+                "match_ids": [3943043],
+                "embedding_models": ["text-embedding-3-small"],
+            },
+        )
+        assert response.status_code == 202

--- a/backend/tests/integration/test_seed_load_live.py
+++ b/backend/tests/integration/test_seed_load_live.py
@@ -1,0 +1,167 @@
+"""End-to-end integration test for seed_load against real databases.
+
+These tests require a running Docker Compose stack (postgres + sqlserver).
+They download the real GitHub Release tarball (cached under
+``~/.cache/rag-challenge-seed``) and load it into the actual databases.
+
+**Marked as ``@pytest.mark.integration`` and skipped in CI by default.**
+Run locally with:
+
+    pytest -m integration backend/tests/integration/test_seed_load_live.py -v
+
+To test locally without docker:
+
+    pytest tests/unit/test_seed_load.py -v
+
+This file is intentionally thin: the unit tests cover argparse, idempotency,
+sha256 validation, staging, and error paths. Here we only verify the
+happy path against real infrastructure.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+
+import pytest
+
+from scripts import seed_load
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_release_exists() -> bool:
+    """Return True if the seed tarball URL responds with HTTP 200."""
+    try:
+        req = urllib.request.Request(seed_load.SEED_URL, method="HEAD")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status == 200
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _require_seed_release():
+    """Skip all tests in this file if the GitHub Release isn't published yet."""
+    if not _seed_release_exists():
+        pytest.skip(
+            f"Seed Release not yet published at {seed_load.SEED_URL}. "
+            "Maintainer must run: "
+            "`python -m scripts.seed_build --i-have-budget` "
+            "and `gh release create seed/v1 seed-v1.tar.gz`."
+        )
+
+
+@pytest.fixture
+def clean_seed_data():
+    """Delete the seed matches from both databases before each test."""
+    for source in ("postgres", "sqlserver"):
+        try:
+            with seed_load._connect(source) as conn:
+                cur = conn.cursor()
+                if source == "postgres":
+                    cur.execute(
+                        "DELETE FROM events_details__quarter_minute WHERE match_id = ANY(%s)",
+                        (list(seed_load.SEED_MATCH_IDS),),
+                    )
+                    cur.execute(
+                        "DELETE FROM events_details WHERE match_id = ANY(%s)",
+                        (list(seed_load.SEED_MATCH_IDS),),
+                    )
+                    cur.execute(
+                        "DELETE FROM events WHERE match_id = ANY(%s)",
+                        (list(seed_load.SEED_MATCH_IDS),),
+                    )
+                    cur.execute(
+                        "DELETE FROM matches WHERE match_id = ANY(%s)",
+                        (list(seed_load.SEED_MATCH_IDS),),
+                    )
+                else:
+                    qmarks = ",".join("?" for _ in seed_load.SEED_MATCH_IDS)
+                    cur.execute(
+                        f"DELETE FROM events_details__15secs_agg WHERE match_id IN ({qmarks})",
+                        seed_load.SEED_MATCH_IDS,
+                    )
+                    cur.execute(
+                        f"DELETE FROM events_details WHERE match_id IN ({qmarks})",
+                        seed_load.SEED_MATCH_IDS,
+                    )
+                    cur.execute(
+                        f"DELETE FROM events WHERE match_id IN ({qmarks})",
+                        seed_load.SEED_MATCH_IDS,
+                    )
+                    cur.execute(
+                        f"DELETE FROM matches WHERE match_id IN ({qmarks})",
+                        seed_load.SEED_MATCH_IDS,
+                    )
+        except Exception as e:
+            pytest.skip(f"Cannot reach {source}: {e}")
+    yield
+
+
+def test_seed_load_populates_postgres(clean_seed_data):
+    """After seed_load, Postgres has both matches with embeddings."""
+    seed_root = seed_load.download_and_extract(seed_load.CACHE_DIR)
+    seed_load.load_into("postgres", seed_root)
+
+    with seed_load._connect("postgres") as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT COUNT(*) FROM matches WHERE match_id = ANY(%s)",
+            (list(seed_load.SEED_MATCH_IDS),),
+        )
+        assert int(cur.fetchone()[0]) == len(seed_load.SEED_MATCH_IDS)
+
+        cur.execute(
+            """
+            SELECT COUNT(*) FROM events_details__quarter_minute
+            WHERE match_id = ANY(%s) AND summary IS NOT NULL
+            """,
+            (list(seed_load.SEED_MATCH_IDS),),
+        )
+        non_null_summaries = int(cur.fetchone()[0])
+        assert non_null_summaries > 1000  # expect ~2500 per match
+
+        cur.execute(
+            """
+            SELECT COUNT(*) FROM events_details__quarter_minute
+            WHERE match_id = ANY(%s) AND summary_embedding_t3_small IS NOT NULL
+            """,
+            (list(seed_load.SEED_MATCH_IDS),),
+        )
+        non_null_embeddings = int(cur.fetchone()[0])
+        assert non_null_embeddings == non_null_summaries
+
+
+def test_seed_load_populates_sqlserver(clean_seed_data):
+    """After seed_load, SQL Server has both matches with embeddings."""
+    seed_root = seed_load.download_and_extract(seed_load.CACHE_DIR)
+    seed_load.load_into("sqlserver", seed_root)
+
+    with seed_load._connect("sqlserver") as conn:
+        cur = conn.cursor()
+        qmarks = ",".join("?" for _ in seed_load.SEED_MATCH_IDS)
+        cur.execute(
+            f"SELECT COUNT(*) FROM matches WHERE match_id IN ({qmarks})",
+            seed_load.SEED_MATCH_IDS,
+        )
+        assert int(cur.fetchone()[0]) == len(seed_load.SEED_MATCH_IDS)
+
+        cur.execute(
+            f"""
+            SELECT COUNT(*) FROM events_details__15secs_agg
+            WHERE match_id IN ({qmarks}) AND embedding_3_small IS NOT NULL
+            """,
+            seed_load.SEED_MATCH_IDS,
+        )
+        assert int(cur.fetchone()[0]) > 1000  # expect ~2500 per match
+
+
+def test_seed_load_second_run_is_noop(clean_seed_data):
+    """Running seed_load twice in a row: second run should exit 0 fast."""
+    seed_root = seed_load.download_and_extract(seed_load.CACHE_DIR)
+    seed_load.load_into("postgres", seed_root)
+
+    # Now idempotency check should return True and load_into should not
+    # be called.
+    assert seed_load.check_idempotency("postgres") is True

--- a/backend/tests/unit/test_full_pipeline_orchestrator.py
+++ b/backend/tests/unit/test_full_pipeline_orchestrator.py
@@ -1,0 +1,113 @@
+"""Unit tests for IngestionService.run_full_pipeline_job()."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.services.ingestion_service import IngestionService
+
+
+class TestRunFullPipelineJob:
+    def _make_service(self):
+        return IngestionService(statsbomb=MagicMock())
+
+    @patch("app.services.ingestion_service.JobService")
+    def test_calls_all_five_stages_in_order(self, _mock_job_service):
+        service = self._make_service()
+        service.run_download_job = MagicMock()
+        service.run_load_job = MagicMock()
+        service.run_aggregate_job = MagicMock()
+        service.run_generate_summaries_job = MagicMock()
+        service.run_rebuild_embeddings_job = MagicMock()
+
+        payload = {
+            "source": "postgres",
+            "match_ids": [3943043],
+            "competition_id": 55,
+            "season_id": 282,
+        }
+        service.run_full_pipeline_job("job-1", payload)
+
+        # Confirm order by inspecting mock.mock_calls on a parent
+        call_order = []
+        for method_name in [
+            "run_download_job",
+            "run_load_job",
+            "run_aggregate_job",
+            "run_generate_summaries_job",
+            "run_rebuild_embeddings_job",
+        ]:
+            mock = getattr(service, method_name)
+            if mock.called:
+                call_order.append(method_name)
+        assert call_order == [
+            "run_download_job",
+            "run_load_job",
+            "run_aggregate_job",
+            "run_generate_summaries_job",
+            "run_rebuild_embeddings_job",
+        ]
+
+    @patch("app.services.ingestion_service.JobService")
+    def test_aborts_remaining_stages_on_failure(self, mock_job_service):
+        service = self._make_service()
+        service.run_download_job = MagicMock()
+        service.run_load_job = MagicMock(side_effect=RuntimeError("load failed"))
+        service.run_aggregate_job = MagicMock()
+        service.run_generate_summaries_job = MagicMock()
+        service.run_rebuild_embeddings_job = MagicMock()
+
+        payload = {"source": "postgres", "match_ids": [1]}
+        service.run_full_pipeline_job("job-2", payload)
+
+        # download + load were called, the rest were not
+        service.run_download_job.assert_called_once()
+        service.run_load_job.assert_called_once()
+        service.run_aggregate_job.assert_not_called()
+        service.run_generate_summaries_job.assert_not_called()
+        service.run_rebuild_embeddings_job.assert_not_called()
+        mock_job_service.fail.assert_called_once()
+
+    @patch("app.services.ingestion_service.JobService")
+    def test_forwards_payload_to_each_stage(self, _mock_job_service):
+        service = self._make_service()
+        service.run_download_job = MagicMock()
+        service.run_load_job = MagicMock()
+        service.run_aggregate_job = MagicMock()
+        service.run_generate_summaries_job = MagicMock()
+        service.run_rebuild_embeddings_job = MagicMock()
+
+        payload = {
+            "source": "postgres",
+            "match_ids": [3943043, 3869685],
+            "competition_id": 55,
+            "season_id": 282,
+            "language": "english",
+            "embedding_models": ["text-embedding-3-small"],
+        }
+        service.run_full_pipeline_job("job-3", payload)
+
+        # Each stage receives the same top-level payload; each stage
+        # extracts what it needs (documented contract).
+        for method_name in [
+            "run_download_job",
+            "run_load_job",
+            "run_aggregate_job",
+            "run_generate_summaries_job",
+            "run_rebuild_embeddings_job",
+        ]:
+            mock = getattr(service, method_name)
+            assert mock.call_args[0][1] == payload
+
+    @patch("app.services.ingestion_service.JobService")
+    def test_job_marked_complete_on_success(self, mock_job_service):
+        service = self._make_service()
+        service.run_download_job = MagicMock()
+        service.run_load_job = MagicMock()
+        service.run_aggregate_job = MagicMock()
+        service.run_generate_summaries_job = MagicMock()
+        service.run_rebuild_embeddings_job = MagicMock()
+
+        service.run_full_pipeline_job("job-4", {"source": "postgres", "match_ids": [1]})
+        mock_job_service.complete.assert_called_once()
+        mock_job_service.fail.assert_not_called()

--- a/backend/tests/unit/test_seed_build.py
+++ b/backend/tests/unit/test_seed_build.py
@@ -9,10 +9,17 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
 from scripts import seed_build
+
+# Resolve the backend/ directory dynamically so these subprocess-based
+# tests work in any checkout (local devcontainer at /workspace/backend,
+# GitHub Actions at /home/runner/work/RAG-Challenge/RAG-Challenge/backend,
+# etc.).
+BACKEND_DIR = Path(__file__).resolve().parents[2]
 
 
 # ---------------------------------------------------------------------------
@@ -65,7 +72,7 @@ class TestCliBudgetFlag:
             ],
             capture_output=True,
             text=True,
-            cwd="/workspace/backend",
+            cwd=str(BACKEND_DIR),
         )
         assert result.returncode != 0
         assert "--i-have-budget" in result.stderr
@@ -88,7 +95,7 @@ class TestCliBudgetFlag:
             ],
             capture_output=True,
             text=True,
-            cwd="/workspace/backend",
+            cwd=str(BACKEND_DIR),
             env=env,
         )
         # Should fail later (at postgres connect), not at the budget
@@ -116,7 +123,7 @@ class TestCliMatchIdsValidation:
             ],
             capture_output=True,
             text=True,
-            cwd="/workspace/backend",
+            cwd=str(BACKEND_DIR),
         )
         assert result.returncode != 0
         assert "unknown match_ids" in result.stderr
@@ -138,7 +145,7 @@ class TestCliMatchIdsValidation:
             ],
             capture_output=True,
             text=True,
-            cwd="/workspace/backend",
+            cwd=str(BACKEND_DIR),
             env=env,
         )
         # Argparse passed (no "unknown match_ids"); failure is elsewhere

--- a/backend/tests/unit/test_seed_build.py
+++ b/backend/tests/unit/test_seed_build.py
@@ -1,0 +1,170 @@
+"""Unit tests for scripts/seed_build.py — argparse and validation only.
+
+The actual export flow requires a running Postgres + OpenAI key, so it's
+covered by the (deferred) integration test. Here we verify the CLI
+guardrails and SEED_MATCH_IDS constants.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from scripts import seed_build
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestSeedConstants:
+    def test_seed_version_is_v1(self):
+        assert seed_build.SEED_VERSION == "v1"
+
+    def test_seed_match_ids_has_both_finals(self):
+        assert 3943043 in seed_build.SEED_MATCH_IDS  # Euro 2024
+        assert 3869685 in seed_build.SEED_MATCH_IDS  # World Cup 2022
+        assert len(seed_build.SEED_MATCH_IDS) == 2
+
+    def test_euro_2024_metadata_correct(self):
+        euro = seed_build.SEED_MATCH_IDS[3943043]
+        assert euro["competition_id"] == 55
+        assert euro["season_id"] == 282
+        assert "Spain" in euro["label"]
+        assert "England" in euro["label"]
+
+    def test_world_cup_2022_metadata_correct(self):
+        wc = seed_build.SEED_MATCH_IDS[3869685]
+        assert wc["competition_id"] == 43
+        assert wc["season_id"] == 106
+        assert "Argentina" in wc["label"]
+        assert "France" in wc["label"]
+
+    def test_embedding_model_is_t3_small(self):
+        assert seed_build.EMBEDDING_MODEL == "text-embedding-3-small"
+
+
+# ---------------------------------------------------------------------------
+# CLI: --i-have-budget required
+# ---------------------------------------------------------------------------
+
+
+class TestCliBudgetFlag:
+    def test_refuses_without_budget_flag(self, tmp_path):
+        """Running without --i-have-budget must fail with non-zero exit."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.seed_build",
+                "--output",
+                str(tmp_path / "x.tar.gz"),
+            ],
+            capture_output=True,
+            text=True,
+            cwd="/workspace/backend",
+        )
+        assert result.returncode != 0
+        assert "--i-have-budget" in result.stderr
+
+    def test_skip_pipeline_bypasses_budget_check(self, tmp_path, monkeypatch):
+        """With --skip-pipeline you don't need --i-have-budget, but you still
+        need Postgres — so the call will fail at _connect_postgres, not at
+        the budget check."""
+        # Run as subprocess to inspect stderr; expect failure at postgres
+        # connect, not at budget check.
+        env = {"PATH": "/usr/bin:/usr/local/bin", "POSTGRES_HOST": "nonexistent-host-xyz"}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.seed_build",
+                "--skip-pipeline",
+                "--output",
+                str(tmp_path / "x.tar.gz"),
+            ],
+            capture_output=True,
+            text=True,
+            cwd="/workspace/backend",
+            env=env,
+        )
+        # Should fail later (at postgres connect), not at the budget
+        # guard. The guard message should NOT appear.
+        assert "--i-have-budget" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# CLI: --match-ids validation
+# ---------------------------------------------------------------------------
+
+
+class TestCliMatchIdsValidation:
+    def test_rejects_unknown_match_id(self, tmp_path):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.seed_build",
+                "--i-have-budget",
+                "--match-ids",
+                "999999",
+                "--output",
+                str(tmp_path / "x.tar.gz"),
+            ],
+            capture_output=True,
+            text=True,
+            cwd="/workspace/backend",
+        )
+        assert result.returncode != 0
+        assert "unknown match_ids" in result.stderr
+
+    def test_accepts_single_known_match_id_with_skip_pipeline(self, tmp_path):
+        """Accept a single seed match_id and proceed past argparse (will
+        fail later at postgres connect, which is OK here)."""
+        env = {"PATH": "/usr/bin:/usr/local/bin", "POSTGRES_HOST": "nonexistent-host-xyz"}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.seed_build",
+                "--skip-pipeline",
+                "--match-ids",
+                "3943043",
+                "--output",
+                str(tmp_path / "x.tar.gz"),
+            ],
+            capture_output=True,
+            text=True,
+            cwd="/workspace/backend",
+            env=env,
+        )
+        # Argparse passed (no "unknown match_ids"); failure is elsewhere
+        assert "unknown match_ids" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# _require_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestRequireApiKey:
+    def test_exits_when_no_key(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(SystemExit) as exc_info:
+            seed_build._require_api_key()
+        assert exc_info.value.code == 2
+
+    def test_passes_when_openai_key_set(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_KEY", "sk-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        # Should not raise
+        seed_build._require_api_key()
+
+    def test_passes_when_openai_api_key_set(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        seed_build._require_api_key()

--- a/backend/tests/unit/test_seed_load.py
+++ b/backend/tests/unit/test_seed_load.py
@@ -14,6 +14,10 @@ import pytest
 
 from scripts import seed_load
 
+# Resolve the backend/ directory dynamically (see test_seed_build.py for
+# rationale).
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -236,7 +240,7 @@ class TestSeedLoadMain:
             [sys.executable, "-m", "scripts.seed_load", "--help"],
             capture_output=True,
             text=True,
-            cwd="/workspace/backend",
+            cwd=str(BACKEND_DIR),
         )
         assert result.returncode == 0
         assert "source" in result.stdout
@@ -247,8 +251,6 @@ class TestSeedLoadMain:
         self, mock_download, mock_idem
     ):
         mock_idem.return_value = True
-        exit_code = seed_load.main.__wrapped__() if hasattr(seed_load.main, "__wrapped__") else None
-        # main uses sys.argv so we call it via a light wrapper
         with patch.object(sys, "argv", ["seed_load", "--source", "postgres"]):
             rc = seed_load.main()
         assert rc == 0

--- a/backend/tests/unit/test_seed_load.py
+++ b/backend/tests/unit/test_seed_load.py
@@ -1,0 +1,298 @@
+"""Unit tests for scripts/seed_load.py."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts import seed_load
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestSeedLoadConstants:
+    def test_seed_version_matches_build(self):
+        assert seed_load.SEED_VERSION == "v1"
+
+    def test_seed_match_ids_both_finals(self):
+        assert set(seed_load.SEED_MATCH_IDS) == {3943043, 3869685}
+
+    def test_seed_url_points_to_github_release(self):
+        assert "github.com/erincon01/RAG-Challenge/releases" in seed_load.SEED_URL
+        assert "seed-v1.tar.gz" in seed_load.SEED_URL
+
+
+# ---------------------------------------------------------------------------
+# check_idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestCheckIdempotency:
+    @patch("scripts.seed_load._connect")
+    def test_returns_true_when_both_matches_and_embeddings_present(
+        self, mock_connect
+    ):
+        cur = MagicMock()
+        # matches count = 2, embeddings distinct match_id count = 2
+        cur.fetchone.side_effect = [(2,), (2,)]
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        mock_connect.return_value.__enter__.return_value = conn
+        mock_connect.return_value.__exit__.return_value = False
+
+        assert seed_load.check_idempotency("postgres") is True
+
+    @patch("scripts.seed_load._connect")
+    def test_returns_false_when_matches_missing(self, mock_connect):
+        cur = MagicMock()
+        cur.fetchone.return_value = (0,)
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        mock_connect.return_value.__enter__.return_value = conn
+        mock_connect.return_value.__exit__.return_value = False
+
+        assert seed_load.check_idempotency("postgres") is False
+
+    @patch("scripts.seed_load._connect")
+    def test_returns_false_when_matches_present_but_embeddings_missing(
+        self, mock_connect
+    ):
+        cur = MagicMock()
+        cur.fetchone.side_effect = [(2,), (0,)]
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        mock_connect.return_value.__enter__.return_value = conn
+        mock_connect.return_value.__exit__.return_value = False
+
+        assert seed_load.check_idempotency("postgres") is False
+
+    @patch("scripts.seed_load._connect")
+    def test_returns_false_when_connect_raises(self, mock_connect):
+        mock_connect.side_effect = RuntimeError("db down")
+        assert seed_load.check_idempotency("postgres") is False
+
+
+# ---------------------------------------------------------------------------
+# download_and_extract
+# ---------------------------------------------------------------------------
+
+
+def _make_valid_tarball(tmp_path: Path) -> Path:
+    """Build a minimal valid seed tarball with manifest + files."""
+    build = tmp_path / "build"
+    seed_dir = build / "seed" / "v1"
+    match_dir = seed_dir / "3943043"
+    match_dir.mkdir(parents=True)
+
+    match_content = json.dumps({"match_id": 3943043})
+    events_content = json.dumps([{"id": "e1"}])
+    summaries_content = (
+        '{"row_id": 1, "match_id": 3943043, "period": 1, "minute": 0, '
+        '"quarter_minute": 1, "summary": "Kickoff."}\n'
+    )
+    embeddings_content = '{"row_id": 1, "vector": [0.1, 0.2]}\n'
+
+    (match_dir / "match.json").write_text(match_content)
+    (match_dir / "events.json").write_text(events_content)
+    (match_dir / "summaries.jsonl").write_text(summaries_content)
+    (match_dir / "embeddings_t3_small.jsonl").write_text(embeddings_content)
+
+    files_manifest = {}
+    for fname in ("match.json", "events.json", "summaries.jsonl", "embeddings_t3_small.jsonl"):
+        fpath = match_dir / fname
+        files_manifest[f"3943043/{fname}"] = hashlib.sha256(fpath.read_bytes()).hexdigest()
+
+    manifest = {
+        "version": "v1",
+        "embedding_model": "text-embedding-3-small",
+        "matches": [{"match_id": 3943043, "label": "Test", "competition_id": 55, "season_id": 282}],
+        "files": files_manifest,
+    }
+    (seed_dir / "manifest.json").write_text(json.dumps(manifest))
+
+    tarball = tmp_path / "seed-v1.tar.gz"
+    with tarfile.open(tarball, "w:gz") as tar:
+        tar.add(build / "seed", arcname="seed")
+    return tarball
+
+
+class TestDownloadAndExtract:
+    def test_extracts_valid_tarball_and_verifies_manifest(self, tmp_path, monkeypatch):
+        tarball = _make_valid_tarball(tmp_path)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # Pre-place the tarball so download is skipped
+        import shutil as _sh
+
+        _sh.copyfile(tarball, cache_dir / "seed-v1.tar.gz")
+
+        result = seed_load.download_and_extract(cache_dir)
+        assert result.exists()
+        assert (result / "manifest.json").exists()
+        assert (result / "3943043" / "match.json").exists()
+
+    def test_raises_on_sha_mismatch(self, tmp_path):
+        tarball = _make_valid_tarball(tmp_path)
+        # Unpack, tamper, re-pack
+        extract_dir = tmp_path / "extracted"
+        extract_dir.mkdir()
+        with tarfile.open(tarball, "r:gz") as tar:
+            tar.extractall(extract_dir, filter="data")
+        (extract_dir / "seed" / "v1" / "3943043" / "match.json").write_text(
+            '{"tampered": true}'
+        )
+        # Re-pack without updating manifest
+        tampered = tmp_path / "tampered.tar.gz"
+        with tarfile.open(tampered, "w:gz") as tar:
+            tar.add(extract_dir / "seed", arcname="seed")
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        import shutil as _sh
+
+        _sh.copyfile(tampered, cache_dir / "seed-v1.tar.gz")
+
+        with pytest.raises(RuntimeError, match="sha256 mismatch"):
+            seed_load.download_and_extract(cache_dir)
+
+    def test_raises_on_missing_manifest(self, tmp_path):
+        # Build a tarball without manifest.json
+        build = tmp_path / "build"
+        seed_dir = build / "seed" / "v1" / "3943043"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "match.json").write_text("{}")
+        tarball = tmp_path / "bad.tar.gz"
+        with tarfile.open(tarball, "w:gz") as tar:
+            tar.add(build / "seed", arcname="seed")
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        import shutil as _sh
+
+        _sh.copyfile(tarball, cache_dir / "seed-v1.tar.gz")
+        with pytest.raises(RuntimeError, match="manifest.json"):
+            seed_load.download_and_extract(cache_dir)
+
+
+# ---------------------------------------------------------------------------
+# _stage_seed_for_ingestion
+# ---------------------------------------------------------------------------
+
+
+class TestStageSeedForIngestion:
+    def test_copies_events_and_wraps_matches_in_list(self, tmp_path):
+        # Build a minimal seed layout
+        seed_root = tmp_path / "seed"
+        match_dir = seed_root / "3943043"
+        match_dir.mkdir(parents=True)
+        (match_dir / "match.json").write_text('{"match_id": 3943043}')
+        (match_dir / "events.json").write_text('[{"id": "e1"}]')
+
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        match_ids = seed_load._stage_seed_for_ingestion(seed_root, staging)
+
+        assert match_ids == [3943043]
+        # Events copied to {staging}/events/3943043.json
+        events_copy = staging / "events" / "3943043.json"
+        assert events_copy.exists()
+        assert json.loads(events_copy.read_text()) == [{"id": "e1"}]
+        # Matches wrapped in a list
+        matches_seed = staging / "matches" / "seed.json"
+        assert matches_seed.exists()
+        matches_list = json.loads(matches_seed.read_text())
+        assert isinstance(matches_list, list)
+        assert matches_list[0]["match_id"] == 3943043
+
+    def test_skips_non_numeric_directories(self, tmp_path):
+        seed_root = tmp_path / "seed"
+        seed_root.mkdir()
+        (seed_root / "not_a_match").mkdir()
+        (seed_root / "manifest.json").write_text("{}")
+        # Only numeric-named dirs with required files become match_ids
+        match_ids = seed_load._stage_seed_for_ingestion(seed_root, tmp_path / "staging")
+        assert match_ids == []
+
+
+# ---------------------------------------------------------------------------
+# main() argparse + idempotency flow
+# ---------------------------------------------------------------------------
+
+
+class TestSeedLoadMain:
+    def test_help_exits_zero(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "scripts.seed_load", "--help"],
+            capture_output=True,
+            text=True,
+            cwd="/workspace/backend",
+        )
+        assert result.returncode == 0
+        assert "source" in result.stdout
+
+    @patch("scripts.seed_load.check_idempotency")
+    @patch("scripts.seed_load.download_and_extract")
+    def test_skips_download_when_all_sources_idempotent(
+        self, mock_download, mock_idem
+    ):
+        mock_idem.return_value = True
+        exit_code = seed_load.main.__wrapped__() if hasattr(seed_load.main, "__wrapped__") else None
+        # main uses sys.argv so we call it via a light wrapper
+        with patch.object(sys, "argv", ["seed_load", "--source", "postgres"]):
+            rc = seed_load.main()
+        assert rc == 0
+        mock_download.assert_not_called()
+
+    @patch("scripts.seed_load.check_idempotency", return_value=False)
+    @patch(
+        "scripts.seed_load.download_and_extract",
+        side_effect=RuntimeError("network error"),
+    )
+    def test_returns_nonzero_on_download_failure(self, _mock_dl, _mock_idem):
+        with patch.object(sys, "argv", ["seed_load", "--source", "postgres"]):
+            rc = seed_load.main()
+        assert rc == 1
+
+    @patch("scripts.seed_load.load_into")
+    @patch(
+        "scripts.seed_load.download_and_extract",
+        return_value=Path("/tmp/fake_seed"),
+    )
+    @patch("scripts.seed_load.check_idempotency", return_value=False)
+    def test_happy_path_calls_load_into_per_source(
+        self, _mock_idem, _mock_dl, mock_load
+    ):
+        mock_load.return_value = {
+            "match_ids": [1, 2],
+            "aggregated_rows": 100,
+            "summaries_updated": 100,
+            "embeddings_updated": 100,
+        }
+        with patch.object(sys, "argv", ["seed_load", "--source", "both"]):
+            rc = seed_load.main()
+        assert rc == 0
+        assert mock_load.call_count == 2
+        called_sources = [call.args[0] for call in mock_load.call_args_list]
+        assert called_sources == ["postgres", "sqlserver"]
+
+    @patch("scripts.seed_load.load_into", side_effect=RuntimeError("load failed"))
+    @patch(
+        "scripts.seed_load.download_and_extract",
+        return_value=Path("/tmp/fake_seed"),
+    )
+    @patch("scripts.seed_load.check_idempotency", return_value=False)
+    def test_returns_nonzero_when_load_fails(self, _idem, _dl, _load):
+        with patch.object(sys, "argv", ["seed_load", "--source", "postgres"]):
+            rc = seed_load.main()
+        assert rc == 1

--- a/backend/tests/unit/test_summary_generation.py
+++ b/backend/tests/unit/test_summary_generation.py
@@ -1,0 +1,350 @@
+"""Unit tests for the summary-generation stage of IngestionService."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from app.adapters.openai_client import OpenAIAdapter
+from app.services.ingestion_service import IngestionService
+
+
+# ---------------------------------------------------------------------------
+# Prompt template loading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPromptTemplate:
+    def test_template_file_exists_and_is_non_empty(self):
+        template_path = (
+            Path(__file__).resolve().parents[2]
+            / "app"
+            / "services"
+            / "prompts"
+            / "event_summary.md"
+        )
+        assert template_path.exists(), f"Missing template at {template_path}"
+        content = template_path.read_text(encoding="utf-8")
+        assert len(content) > 100
+        # Sanity: must contain all expected placeholders
+        for placeholder in (
+            "{language}",
+            "{competition_name}",
+            "{match_date}",
+            "{home_team}",
+            "{away_team}",
+            "{period}",
+            "{minute}",
+            "{quarter_minute}",
+            "{events_json}",
+        ):
+            assert placeholder in content, (
+                f"Placeholder {placeholder} missing from template"
+            )
+
+    def test_template_formats_without_keyerror(self):
+        service = IngestionService(statsbomb=MagicMock())
+        template = service._load_prompt_template()
+        formatted = template.format(
+            language="english",
+            competition_name="UEFA Euro",
+            match_date="2024-07-14",
+            home_team="Spain",
+            away_team="England",
+            period=1,
+            minute=10,
+            quarter_minute=2,
+            events_json='{"type": "Pass"}',
+        )
+        assert "Spain" in formatted
+        assert "England" in formatted
+        assert "{" not in formatted.replace("{", "__OPEN__").replace(
+            "__OPEN__", ""
+        )  # no remaining placeholders
+
+    def test_template_is_cached_after_first_load(self):
+        service = IngestionService(statsbomb=MagicMock())
+        first = service._load_prompt_template()
+        second = service._load_prompt_template()
+        assert first is second  # identity, not equality — confirms cache
+
+
+# ---------------------------------------------------------------------------
+# _fetch_aggregation_rows_for_summary
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAggregationRowsForSummary:
+    def test_postgres_filters_null_summary_and_match_ids(self):
+        service = IngestionService(statsbomb=MagicMock())
+        cur = MagicMock()
+        cur.fetchall.return_value = [
+            (1, 1, 10, 2, '{"type": "Pass"}'),
+            (2, 1, 10, 3, '{"type": "Shot"}'),
+        ]
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        rows = service._fetch_aggregation_rows_for_summary(conn, "postgres", [3943043])
+
+        assert len(rows) == 2
+        assert rows[0] == (1, 1, 10, 2, '{"type": "Pass"}')
+        # Confirm SQL uses the right table + filters
+        sql = cur.execute.call_args[0][0]
+        assert "events_details__quarter_minute" in sql
+        assert "summary IS NULL" in sql
+        assert "match_id = ANY" in sql
+
+    def test_sqlserver_uses_correct_table(self):
+        service = IngestionService(statsbomb=MagicMock())
+        cur = MagicMock()
+        cur.fetchall.return_value = []
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        service._fetch_aggregation_rows_for_summary(
+            conn, "sqlserver", [3943043, 3869685]
+        )
+
+        sql = cur.execute.call_args[0][0]
+        assert "events_details__15secs_agg" in sql
+        assert "summary IS NULL" in sql
+        # SQL Server uses ? placeholders, one per match_id
+        assert sql.count("?") == 2
+
+    def test_empty_match_ids_selects_all_null_summary_rows(self):
+        service = IngestionService(statsbomb=MagicMock())
+        cur = MagicMock()
+        cur.fetchall.return_value = []
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        service._fetch_aggregation_rows_for_summary(conn, "postgres", [])
+
+        sql = cur.execute.call_args[0][0]
+        assert "summary IS NULL" in sql
+        assert "match_id" not in sql.split("WHERE")[1]
+
+
+# ---------------------------------------------------------------------------
+# _update_summary_for_row
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSummaryForRow:
+    def test_postgres_uses_percent_s_placeholder(self):
+        service = IngestionService(statsbomb=MagicMock())
+        cur = MagicMock()
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        service._update_summary_for_row(conn, "postgres", 42, "Spain attacks.")
+
+        sql, params = cur.execute.call_args[0]
+        assert "events_details__quarter_minute" in sql
+        assert "%s" in sql
+        assert "?" not in sql
+        assert params == ("Spain attacks.", 42)
+
+    def test_sqlserver_uses_question_mark_placeholder(self):
+        service = IngestionService(statsbomb=MagicMock())
+        cur = MagicMock()
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        service._update_summary_for_row(conn, "sqlserver", 7, "Goal!")
+
+        sql, params = cur.execute.call_args[0]
+        assert "events_details__15secs_agg" in sql
+        assert "?" in sql
+        assert "%s" not in sql
+        assert params == ("Goal!", 7)
+
+
+# ---------------------------------------------------------------------------
+# _fetch_match_info_for_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestFetchMatchInfoForPrompt:
+    def test_returns_dict_keyed_by_match_id(self):
+        service = IngestionService(statsbomb=MagicMock())
+        cur = MagicMock()
+        cur.fetchall.return_value = [
+            (
+                3943043,
+                "UEFA Euro",
+                "2024-07-14",
+                "Spain",
+                "England",
+            ),
+        ]
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        info = service._fetch_match_info_for_prompt(conn, "postgres", [3943043])
+
+        assert 3943043 in info
+        assert info[3943043]["competition_name"] == "UEFA Euro"
+        assert info[3943043]["home_team"] == "Spain"
+        assert info[3943043]["away_team"] == "England"
+
+    def test_missing_match_returns_placeholder_info(self):
+        service = IngestionService(statsbomb=MagicMock())
+        cur = MagicMock()
+        cur.fetchall.return_value = []
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        info = service._fetch_match_info_for_prompt(conn, "postgres", [123])
+
+        # No crash, just empty dict
+        assert info == {}
+
+
+# ---------------------------------------------------------------------------
+# run_generate_summaries_job
+# ---------------------------------------------------------------------------
+
+
+class TestRunGenerateSummariesJob:
+    def _make_service(self):
+        service = IngestionService(statsbomb=MagicMock())
+        return service
+
+    @patch("app.services.ingestion_service.OpenAIAdapter")
+    @patch("app.services.ingestion_service.JobService")
+    def test_happy_path_calls_chat_and_updates_row(
+        self, mock_job_service, mock_adapter_cls
+    ):
+        service = self._make_service()
+        mock_adapter = MagicMock(spec=OpenAIAdapter)
+        mock_adapter.create_chat_completion.return_value = "Spain attacks."
+        mock_adapter_cls.return_value = mock_adapter
+
+        # Mock connection with match info + aggregation rows
+        cur = MagicMock()
+        # First fetchall: match info for prompt
+        # Second fetchall: aggregation rows
+        cur.fetchall.side_effect = [
+            [(3943043, "UEFA Euro", "2024-07-14", "Spain", "England")],
+            [(1, 1, 10, 2, '{"type":"Pass"}'), (2, 1, 10, 3, '{"type":"Shot"}')],
+        ]
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        with patch.object(service, "_get_connection") as mock_get_conn:
+            mock_get_conn.return_value.__enter__.return_value = conn
+            mock_get_conn.return_value.__exit__.return_value = False
+
+            service.run_generate_summaries_job(
+                "job-1", {"source": "postgres", "match_ids": [3943043]}
+            )
+
+        # Chat completion called once per row
+        assert mock_adapter.create_chat_completion.call_count == 2
+        # Job completed
+        mock_job_service.complete.assert_called_once()
+        mock_job_service.fail.assert_not_called()
+
+    @patch("app.services.ingestion_service.OpenAIAdapter")
+    @patch("app.services.ingestion_service.JobService")
+    def test_skips_rows_with_empty_events_json(
+        self, mock_job_service, mock_adapter_cls
+    ):
+        service = self._make_service()
+        mock_adapter = MagicMock(spec=OpenAIAdapter)
+        mock_adapter.create_chat_completion.return_value = "Narration."
+        mock_adapter_cls.return_value = mock_adapter
+
+        cur = MagicMock()
+        cur.fetchall.side_effect = [
+            [(3943043, "UEFA Euro", "2024-07-14", "Spain", "England")],
+            [
+                (1, 1, 10, 2, ""),  # empty events → skip
+                (2, 1, 10, 3, '{"type":"Shot"}'),  # valid → process
+            ],
+        ]
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        with patch.object(service, "_get_connection") as mock_get_conn:
+            mock_get_conn.return_value.__enter__.return_value = conn
+            mock_get_conn.return_value.__exit__.return_value = False
+
+            service.run_generate_summaries_job(
+                "job-2", {"source": "postgres", "match_ids": [3943043]}
+            )
+
+        # Only called for non-empty row
+        assert mock_adapter.create_chat_completion.call_count == 1
+
+    @patch("app.services.ingestion_service.OpenAIAdapter")
+    @patch("app.services.ingestion_service.JobService")
+    def test_continues_on_partial_row_failure(self, mock_job_service, mock_adapter_cls):
+        service = self._make_service()
+        mock_adapter = MagicMock(spec=OpenAIAdapter)
+        # First call raises, second succeeds
+        mock_adapter.create_chat_completion.side_effect = [
+            RuntimeError("boom"),
+            "Second narration.",
+        ]
+        mock_adapter_cls.return_value = mock_adapter
+
+        cur = MagicMock()
+        cur.fetchall.side_effect = [
+            [(3943043, "UEFA Euro", "2024-07-14", "Spain", "England")],
+            [
+                (1, 1, 10, 2, '{"type":"Pass"}'),
+                (2, 1, 10, 3, '{"type":"Shot"}'),
+            ],
+        ]
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        with patch.object(service, "_get_connection") as mock_get_conn:
+            mock_get_conn.return_value.__enter__.return_value = conn
+            mock_get_conn.return_value.__exit__.return_value = False
+
+            service.run_generate_summaries_job(
+                "job-3", {"source": "postgres", "match_ids": [3943043]}
+            )
+
+        # Both rows attempted
+        assert mock_adapter.create_chat_completion.call_count == 2
+        # Job still completes (doesn't fail on single-row error)
+        mock_job_service.complete.assert_called_once()
+
+    @patch("app.services.ingestion_service.OpenAIAdapter")
+    @patch("app.services.ingestion_service.JobService")
+    def test_strips_summary_whitespace(self, mock_job_service, mock_adapter_cls):
+        service = self._make_service()
+        mock_adapter = MagicMock(spec=OpenAIAdapter)
+        mock_adapter.create_chat_completion.return_value = (
+            "  \n  Spain attacks.  \n\n  "
+        )
+        mock_adapter_cls.return_value = mock_adapter
+
+        cur = MagicMock()
+        cur.fetchall.side_effect = [
+            [(3943043, "UEFA Euro", "2024-07-14", "Spain", "England")],
+            [(1, 1, 10, 2, '{"type":"Pass"}')],
+        ]
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        with patch.object(service, "_get_connection") as mock_get_conn:
+            mock_get_conn.return_value.__enter__.return_value = conn
+            mock_get_conn.return_value.__exit__.return_value = False
+
+            service.run_generate_summaries_job(
+                "job-4", {"source": "postgres", "match_ids": [3943043]}
+            )
+
+        # Find the UPDATE call
+        update_calls = [
+            c for c in cur.execute.call_args_list if "UPDATE" in str(c.args[0]).upper()
+        ]
+        assert len(update_calls) == 1
+        params = update_calls[0].args[1]
+        assert params[0] == "Spain attacks."  # stripped

--- a/data/seed/README.md
+++ b/data/seed/README.md
@@ -1,0 +1,163 @@
+# Seed Dataset
+
+Pre-computed data for two canonical football finals, used to populate the
+dashboard on first run without requiring an OpenAI API key.
+
+## What's in the seed
+
+| Match | Competition | `match_id` | Date | Result |
+|-------|-------------|------------|------|--------|
+| **Spain 2-1 England** | UEFA Euro 2024 Final | `3943043` | 2024-07-14 | AET |
+| **Argentina 3-3 France** (pens. 4-2) | FIFA World Cup 2022 Final | `3869685` | 2022-12-18 | Penalties |
+
+Both matches have:
+
+- Raw StatsBomb match metadata
+- Raw events (~4,000 events per match across 120+ minutes)
+- 15-second bucket aggregations (~2,500 rows per match)
+- LLM-generated narrative summaries for each bucket
+- Pre-computed `text-embedding-3-small` vectors (1536 dims) for each summary
+
+Approximately **5,000 embedded rows total** — enough to demo the full
+RAG pipeline end-to-end.
+
+## Data source & licensing
+
+Raw data comes from **StatsBomb Open Data** (
+<https://github.com/statsbomb/open-data>
+), licensed under **CC BY-NC-SA 4.0**. See their repo for the full license
+and terms. This project references StatsBomb data for non-commercial
+educational use, downloading it on demand from their public GitHub.
+
+Summaries and embeddings are **generated** by this project using
+OpenAI's `gpt-4o-mini` (summaries) and `text-embedding-3-small`
+(embeddings), and distributed under the same CC BY-NC-SA 4.0 license.
+
+**StatsBomb raw JSON is NOT committed to this repository.** The seed
+tarball hosted on GitHub Releases is a derivative work containing
+pre-processed aggregations and generated narratives — no raw event data
+from StatsBomb is stored in git.
+
+## Where the seed lives
+
+The actual seed tarball is published as a **GitHub Release asset** at:
+
+<https://github.com/erincon01/RAG-Challenge/releases/download/seed/v1/seed-v1.tar.gz>
+
+It is **not** in this directory and **not** in git history. This
+README is the only thing shipped in the repo; the tarball is downloaded
+on demand by `backend/scripts/seed_load.py` into `~/.cache/rag-challenge-seed/`.
+
+## How the seed is loaded
+
+On first `Reopen in Container`, `.devcontainer/post-create.sh` calls
+`python -m scripts.seed_load --source both`, which:
+
+1. Checks idempotency: if both match_ids are already in the `matches`
+   table AND have non-null embeddings in the aggregation table, exits 0
+   without touching anything.
+2. Downloads the tarball from the GitHub Release (if not already cached
+   locally).
+3. Verifies sha256 of every file against `manifest.json`.
+4. Stages the match + events JSON files into the layout expected by
+   `IngestionService._load_matches` / `_load_events`.
+5. Runs the load + aggregate steps against both PostgreSQL and SQL Server.
+6. UPDATEs `summary` and `summary_embedding_t3_small` columns from the
+   pre-computed JSONL files inside the tarball.
+
+**No OpenAI calls. No API key required.**
+
+## How to re-seed manually
+
+If the automatic post-create seed load fails (network issues, seed not
+yet published, etc.) or you want to reset:
+
+```bash
+make seed                           # both databases
+make seed-force                     # re-seed even if already present
+cd backend && python -m scripts.seed_load --source postgres
+cd backend && python -m scripts.seed_load --source sqlserver
+```
+
+To clear the local cache and force a fresh download:
+
+```bash
+rm -rf ~/.cache/rag-challenge-seed
+make seed
+```
+
+To remove seed data from the database:
+
+```sql
+-- PostgreSQL
+DELETE FROM events_details__quarter_minute WHERE match_id IN (3943043, 3869685);
+DELETE FROM events_details WHERE match_id IN (3943043, 3869685);
+DELETE FROM events WHERE match_id IN (3943043, 3869685);
+DELETE FROM matches WHERE match_id IN (3943043, 3869685);
+
+-- SQL Server (same statements, uses `events_details__15secs_agg` for the agg table)
+```
+
+## How to regenerate the seed tarball (maintainer only)
+
+The seed is built once per `vN` bump by a maintainer with an OpenAI key.
+The process is **paid** (~$0.30 with `gpt-4o-mini` + `text-embedding-3-small`
+for both matches).
+
+```bash
+# 1. Set OPENAI_KEY in backend/.env or .env.docker
+# 2. Start the full stack
+docker compose up -d
+
+# 3. Build the seed — runs the full pipeline then exports from Postgres
+cd backend
+python -m scripts.seed_build --i-have-budget --output ../seed-v1.tar.gz
+
+# 4. Review the output
+tar tzf ../seed-v1.tar.gz | head -20
+
+# 5. Publish
+gh release create seed/v1 ../seed-v1.tar.gz \
+  --title "Seed dataset v1" \
+  --notes "Pre-computed summaries and embeddings for Euro 2024 + WC 2022 finals."
+```
+
+To add more matches to a future version, edit `SEED_MATCH_IDS` in
+`backend/scripts/seed_build.py` and `backend/scripts/seed_load.py`, bump
+`SEED_VERSION` to `v2`, rebuild, and publish a new Release at `seed/v2`.
+
+## Tarball layout
+
+```
+seed/
+  v1/
+    manifest.json              # version, embedding model, sha256 per file
+    3943043/
+      match.json               # raw StatsBomb match metadata
+      events.json              # raw StatsBomb events list
+      summaries.jsonl          # one {row_id, match_id, period, minute, quarter_minute, summary} per line
+      embeddings_t3_small.jsonl  # one {row_id, vector} per line (1536-dim)
+    3869685/
+      match.json
+      events.json
+      summaries.jsonl
+      embeddings_t3_small.jsonl
+```
+
+`manifest.json` schema:
+
+```json
+{
+  "version": "v1",
+  "embedding_model": "text-embedding-3-small",
+  "matches": [
+    {"match_id": 3943043, "label": "Euro 2024 Final (Spain 2-1 England)", "competition_id": 55, "season_id": 282},
+    {"match_id": 3869685, "label": "World Cup 2022 Final (Argentina 3-3 France, pens 4-2)", "competition_id": 43, "season_id": 106}
+  ],
+  "files": {
+    "3943043/match.json": "abc123...",
+    "3943043/events.json": "def456...",
+    "...": "..."
+  }
+}
+```

--- a/docs/conversation_log.md
+++ b/docs/conversation_log.md
@@ -109,6 +109,69 @@ Cada sesión significativa con un agente AI se documenta aquí para auditoría y
 
 ---
 
+### [2026-04-08] Session 21 — Seed initial dataset (feature/040-seed-initial-dataset)
+
+**Participants:** Eladio Rincon + Claude Code (Claude Opus 4.6)
+**Branch:** feature/040-seed-initial-dataset
+**Related issue:** erincon01/RAG-Challenge#40 (Area 8: Automatic setup and seed data)
+
+#### Problem discovered during exploration
+1. The dashboard at `/dashboard` shows "Sources: 2" but zero matches — the only seeded row was a synthetic `match_id=900001` placeholder with no events.
+2. **Critical gap in the pipeline**: `aggregate` stage wrote `summary = NULL`, but `embeddings/rebuild` filtered `WHERE summary IS NOT NULL`. No embeddings were ever created out of the box. `docs/data-model.md` described "LLM-generated summary" but the generation step did not exist in code.
+3. New devs couldn't try the RAG pipeline without running 4 manual HTTP calls and spending OpenAI tokens.
+
+#### Decisions taken
+- Close the pipeline gap with a new **5th stage**: `run_generate_summaries_job()` + `POST /ingestion/summaries/generate` endpoint. Kept as a separate stage (not folded into aggregate/embeddings) to keep the pipeline composable and cost-model explicit.
+- Prompt template lives in a file (`backend/app/services/prompts/event_summary.md`), loaded once and cached per service instance. Plain text with `str.format()` placeholders — no Jinja2 dependency.
+- Added `POST /ingestion/full-pipeline` as a thin orchestrator over the 5 stages. Uses the same `job_id` for sub-stages and re-sets status to "running" between stages.
+- **Seed dataset = 2 canonical finals**: Euro 2024 Final (3943043) + World Cup 2022 Final (3869685). Both already used as test fixtures in `conftest.py`.
+- **Pre-computed summaries + embeddings** published as a **GitHub Release** asset (`seed/v1`), NOT committed to the repo. Per-user requirement: no StatsBomb JSON in git.
+- **Only `text-embedding-3-small`** in the seed (cheapest, modern, ~1/3 of tarball size vs. seeding all 3 models).
+- `seed_load.py` is idempotent and tolerant to failures: if anything goes wrong, it logs a warning and exits non-zero, but post-create.sh continues so the devcontainer still starts.
+- `seed_build.py` requires explicit `--i-have-budget` flag and `OPENAI_KEY`. Maintainer runs it once per version bump, uploads to GitHub Release.
+- Removed the 900001 placeholder row entirely from post-create.sh (Postgres and SQL Server). Real seed replaces it.
+
+#### Scope of this change
+This is Phase 1 of issue #40. Includes:
+- Summary generation stage (endpoint + service + prompt template)
+- Full-pipeline orchestrator endpoint
+- `seed_load.py` dev-path loader (no API calls)
+- `seed_build.py` maintainer-path builder (needs API key)
+- Devcontainer wiring via post-create.sh
+- Root Makefile with convenience targets
+- Docs: getting-started.md "First run" section + data/seed/README.md
+- 60+ new unit tests and 13 new API tests
+
+#### NOT in scope (follow-ups)
+- **Actually publishing the seed tarball to GitHub Releases** — maintainer must run `seed_build.py --i-have-budget` once with their OpenAI key and then `gh release create seed/v1`. Until that happens, `seed_load.py` will try to download, fail gracefully, and log a warning. Tracked as a manual task in tasks.md Phase 3.10.
+- Integration test (`test_seed_load_live.py`) that requires a running Docker stack — marked `@pytest.mark.integration` and deferred.
+- Dashboard label fix ("Data Sources" is confusingly named) — belongs to a separate frontend UX issue.
+
+#### Files modified
+- `backend/app/services/ingestion_service.py` — added summary generation stage and full-pipeline orchestrator
+- `backend/app/api/v1/ingestion.py` — two new routes and Pydantic request models
+- `.devcontainer/post-create.sh` — removed 900001 placeholder, added seed_load call
+
+#### Files added
+- `backend/app/services/prompts/__init__.py`, `event_summary.md`
+- `backend/scripts/__init__.py`, `seed_build.py`, `seed_load.py`
+- `backend/tests/unit/test_summary_generation.py` (14 tests)
+- `backend/tests/unit/test_full_pipeline_orchestrator.py` (4 tests)
+- `backend/tests/unit/test_seed_build.py` (12 tests)
+- `backend/tests/unit/test_seed_load.py` (17 tests)
+- `backend/tests/api/test_ingestion.py` additions (13 tests)
+- `data/seed/README.md`
+- `Makefile` (new, root level)
+- `openspec/changes/seed-initial-dataset/proposal.md`, `design.md`, `tasks.md`
+
+#### Verification
+- Full pytest suite: **530 passing, 0 warnings** (was 470)
+- `ruff check` clean on `backend/app`, `ruff format --check` clean
+- `bash -n .devcontainer/post-create.sh` syntax valid
+- **Deferred:** actual Docker stack smoke test and first-run verification — requires maintainer to publish the GitHub Release tarball first.
+
+---
+
 ## Fase spec-kit (Sessions 1-12, branch: develop)
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,56 @@ docker compose up --build
 
 - Frontend: http://localhost:5173
 - Backend docs: http://localhost:8000/docs
-- Tests: `cd backend && pytest tests/ -v` (470+ tests, no DB needed)
+- Tests: `cd backend && pytest tests/ -v` (530+ tests, no DB needed)
+
+### First run — seed dataset
+
+On first container open, `.devcontainer/post-create.sh` automatically
+downloads and loads the **seed dataset**: two iconic finals with
+pre-computed summaries and embeddings.
+
+| Match | Competition | match_id |
+|---|---|---|
+| **Spain 2-1 England** | UEFA Euro 2024 Final | 3943043 |
+| **Argentina 3-3 France** (pens. 4-2) | FIFA World Cup 2022 Final | 3869685 |
+
+The seed is **pre-computed**: summaries and 1536-dim embeddings are
+downloaded from a GitHub Release, so **no OpenAI key is required** to
+populate the dashboard on first run.
+
+If the seed load failed (no network, GitHub Release not yet published,
+etc.), the devcontainer still starts. You can retry with:
+
+```bash
+make seed                            # both databases
+make seed-postgres                   # postgres only
+make seed-sqlserver                  # sqlserver only
+cd backend && python -m scripts.seed_load --source both --force  # re-seed
+```
+
+After a successful seed load, the dashboard at http://localhost:5173/dashboard
+should show 2 matches in the explorer, and the chat page can answer
+questions about them (**the chat runtime still needs `OPENAI_KEY` set
+in `.env.docker`** — only the seed loading is offline).
+
+### Adding more matches (requires OpenAI key)
+
+To ingest a new match with the full pipeline (download → load → aggregate
+→ summaries → embeddings):
+
+```bash
+curl -X POST http://localhost:8000/api/v1/ingestion/full-pipeline \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": "postgres",
+    "match_ids": [3943077],
+    "competition_id": 55,
+    "season_id": 282
+  }'
+```
+
+This requires `OPENAI_KEY` to be set and will consume OpenAI tokens
+(approximately $0.15-0.30 per match with GPT-4o-mini + text-embedding-3-small).
 
 ## 2. Understand the project
 

--- a/openspec/changes/seed-initial-dataset/design.md
+++ b/openspec/changes/seed-initial-dataset/design.md
@@ -1,0 +1,370 @@
+## Context
+
+The RAG-Challenge ingestion pipeline exists as 4 separate HTTP endpoints:
+`download → load → aggregate → embeddings/rebuild`. Each is a background job.
+Each was designed to be run manually. See `backend/app/services/ingestion_service.py:187-794`
+for the four `run_*_job()` methods.
+
+Three problems combine to make the out-of-the-box experience frustrating:
+
+1. **The summary-generation step does not exist.**
+   [ingestion_service.py:666-675](backend/app/services/ingestion_service.py#L666-L675) sets
+   `summary=NULL` and `summary_script=NULL` during aggregate.
+   [ingestion_service.py:458-489](backend/app/services/ingestion_service.py#L458-L489) filters
+   `WHERE summary IS NOT NULL` in the embeddings rebuild step. The aggregate stage produces
+   rows that the embedding stage will always skip. Nothing bridges the two. The
+   `docs/data-model.md:137-139` description of "LLM-generated summary" was aspirational.
+
+2. **The devcontainer seeds a dead row.**
+   [.devcontainer/post-create.sh:86-149](.devcontainer/post-create.sh#L86-L149) inserts
+   `match_id=900001` with `json_='{"seed": true}'` — no events, no aggregations, no
+   embeddings. The match explorer sees one phantom row with no detail. The dashboard
+   shows "Sources: 2" but has nothing to explore.
+
+3. **The dashboard UX confuses "data source = database" with "data source = dataset".**
+   [DashboardPage.tsx:15-21](frontend/webapp/src/pages/DashboardPage.tsx#L15-L21) calls
+   `GET /api/v1/sources/status` which returns `[postgres, sqlserver]` connectivity.
+   It always returns 2 items, so the empty state is never triggered. The user's
+   original question "no me aparece ningún data source" is actually about **no matches
+   visible in the explorer**, not about the sources list being empty.
+
+This change fixes (1) and (2) directly, and addresses (3) by ensuring there are real
+matches to explore after first run. The dashboard wording ("Data Sources") is out of scope
+for this change — fixing that is a UX concern for a separate issue.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `Reopen in Container` (or `docker compose up` with post-create equivalent) produce
+  a system where the dashboard shows 2 real matches with full RAG working, **without**
+  requiring OPENAI_KEY.
+- Close the missing summary-generation stage of the pipeline, as a proper, testable,
+  first-class ingestion stage.
+- Allow the maintainer to regenerate the seed dataset with a single command when the
+  prompt template, the embedding model, or the match list changes.
+- Allow a dev **with** an OpenAI key to run the full pipeline end-to-end on arbitrary
+  match_ids via one HTTP call.
+- Keep the repo lean: the ~20 MB seed artifact lives in a GitHub Release, not in git.
+
+**Non-Goals:**
+
+- Not changing the dashboard UI or the "Data Sources" label. That's a frontend UX fix
+  tracked separately.
+- Not adding more than 2 seed matches. Expanding the seed is cheap (edit the matches
+  list in `seed_build.py`, re-run, re-upload); adding more here bloats the first PR.
+- Not replacing the 4 existing ingestion endpoints. They stay as-is; the new
+  `/full-pipeline` endpoint is a thin orchestrator on top.
+- Not implementing a full CLI framework (click/typer). A plain `python -m` script is
+  enough for seed_load / seed_build.
+- Not committing raw StatsBomb JSON to the repo. They are downloaded on demand and
+  referenced as public data (CC BY-NC-SA).
+- Not implementing multi-model seed (only `text-embedding-3-small`). If the user wants
+  `ada-002` or `3-large`, they run `full-pipeline` with their key.
+
+## Decisions
+
+### 1. The missing summary-generation stage is a new first-class pipeline step
+
+**Decision:** Add `POST /api/v1/ingestion/summaries/generate` + `run_generate_summaries_job()`
+as a fifth stage between `aggregate` and `embeddings/rebuild`. Do NOT fold it into either
+of its neighbors.
+
+**Rationale:**
+
+- Keeps the pipeline composable: someone can run `aggregate`, iterate on the prompt
+  template, re-run `summaries/generate` cheaply without re-aggregating.
+- Keeps the cost model explicit: `summaries/generate` is the **expensive** LLM call
+  (one chat completion per bucket), `embeddings/rebuild` is the **cheap** embed call
+  (batched 50 at a time). Collapsing them would hide the cost asymmetry.
+- Matches the existing file structure: one `run_*_job()` method per stage, one endpoint
+  per stage, uniform job-status tracking.
+
+**Alternative rejected:** "Generate summary + embedding in one loop." Rejected because
+it couples prompt iteration to embedding cost and makes the job non-restartable mid-way.
+
+### 2. Prompt template lives in a file, not hardcoded
+
+**Decision:** Create `backend/app/services/prompts/event_summary.md` containing the
+Jinja2-free plain-text template (with `{placeholder}` slots filled via `str.format()`).
+Load it at service init time, not per-call.
+
+**Rationale:**
+
+- Editing a prompt shouldn't require touching Python code.
+- Keeps the prompt version-controlled and reviewable in PRs.
+- No new dependency: `str.format()` is enough. No Jinja2 required.
+
+**Prompt inputs per call:**
+- `match_info`: dict with team names, competition, date
+- `period`, `minute`, `second_window` (e.g. "15-30s")
+- `events_json`: the raw concatenated event JSON from the bucket
+- `language`: "english" by default, configurable (existing settings honor language)
+
+**Prompt output contract:** a 1-3 sentence narrative string, no markdown, no headers.
+Enforced via a simple post-processing strip.
+
+**Alternative rejected:** Using Pydantic structured output / function-calling. Rejected
+because the text-only output is simpler, avoids schema drift, and the downstream
+embedding step only needs the string.
+
+### 3. Embedding model: only `text-embedding-3-small` for the seed
+
+**Decision:** The seed Release tarball contains embeddings for `text-embedding-3-small`
+only (1536 dims, stored in `summary_embedding_t3_small` column).
+
+**Rationale:**
+
+- Cheapest and most modern of the 3 supported models.
+- Existing schema already has the column. No migration.
+- Cuts Release tarball size roughly to 1/3 vs. seeding all 3 models.
+- A dev who wants `ada-002` or `3-large` runs `POST /ingestion/embeddings/rebuild`
+  with their key and the specific `embedding_models` payload.
+
+**Alternative rejected:** Seed all 3 models. Rejected because it triples the Release
+size and 95% of onboarding flows won't touch the other two models.
+
+### 4. Seed artifacts: GitHub Release, not git
+
+**Decision:** Package seed artifacts as a versioned tarball
+(`seed-v1.tar.gz`) and publish it as a GitHub Release asset on a tag like `seed/v1`.
+The Release asset URL is hardcoded in `seed_load.py` with a sha256 in a manifest.
+
+**Rationale:**
+
+- User explicitly asked not to commit raw JSONs to the repo.
+- Embeddings for 2 matches × ~2500 buckets × 1536 floats ≈ 6 MB JSONL gzipped → fits
+  any Release asset limit easily.
+- Versioning via the `seed/vN` tag means updating the seed doesn't touch git history
+  of code. The code references `v1`; to upgrade, a new PR bumps the version string.
+- sha256 check in manifest catches tampering or partial downloads.
+
+**Alternative rejected (1):** Git LFS. Rejected because it adds a required tool to the
+onboarding path and the existing `.gitignore` + DevContainer flow already has enough
+moving parts.
+
+**Alternative rejected (2):** A public S3 bucket. Rejected because GitHub Releases are
+already authenticated to the repo's identity, free, and traceable.
+
+**Alternative rejected (3):** Commit seed to repo. User explicitly said no (and rightly
+so — StatsBomb raw JSON is several MB per match even gzipped).
+
+### 5. Seed loader runs in post-create, idempotently
+
+**Decision:** Modify `.devcontainer/post-create.sh` to invoke `python -m
+backend.scripts.seed_load` after the database bootstrap section. The loader checks
+whether `SELECT COUNT(*) FROM matches WHERE match_id IN (3943043, 3869685)` returns 2
+**and** a non-null `summary_embedding_t3_small` exists for those match_ids' aggregation
+rows. If yes, it exits 0 immediately. If no, it downloads the Release tarball (if
+needed) and loads everything.
+
+**Rationale:**
+
+- First `Reopen in Container` → populates automatically.
+- Subsequent rebuilds → no-op, no network, no wait.
+- Failed downloads → loader exits non-zero, post-create continues (downgrade gracefully
+  instead of blocking the devcontainer from starting). A clear warning is printed.
+
+**Alternative rejected:** A Makefile target `make seed`. Rejected as the *primary* path
+because it requires the user to know it exists. Kept as an **opt-in secondary path**
+for dev experimentation and CI. Both paths call the same `seed_load.py`.
+
+### 6. The 900001 placeholder row is removed
+
+**Decision:** Delete the current `match_id=900001` inserts from
+`.devcontainer/post-create.sh:86-102` (Postgres) and `:131-149` (SQL Server). The real
+seed replaces it.
+
+**Rationale:**
+
+- The placeholder row has no events, no embeddings, and no narrative. It only confuses
+  the explorer.
+- Nothing in the tests depends on `match_id=900001` (confirmed by
+  `grep -r 900001 backend/tests/` — zero hits; all test fixtures use 3943043).
+
+**Alternative rejected:** Keep 900001 as a smoke-test sentinel. Rejected — the seed
+provides 2 real matches which serve the same smoke-test purpose much better.
+
+### 7. Seed_load reuses ingestion service internals
+
+**Decision:** `seed_load.py` imports `IngestionService` and calls its internal methods
+(`_load_matches`, `_load_events`, `_build_aggregations`) with a database connection,
+then issues two custom UPDATEs to set `summary` and `summary_embedding_t3_small` from
+the JSONL files. It does **not** go through the HTTP endpoints.
+
+**Rationale:**
+
+- HTTP routing through localhost:8000 during post-create creates a chicken-and-egg
+  issue (backend may not be ready yet).
+- Direct service invocation is faster (no HTTP overhead for ~5000 rows × 2 DBs).
+- Re-exercises the existing ingestion code paths — if those break, seed_load breaks
+  too, which is a desirable tight coupling for CI detection.
+
+**Trade-off accepted:** `_load_matches` / `_load_events` are currently private. The
+change promotes them to "module-private but accessible from the same package", which
+is fine in Python. No API leakage.
+
+### 8. `full-pipeline` endpoint is an orchestrator, not a new code path
+
+**Decision:** `POST /api/v1/ingestion/full-pipeline` sequentially invokes the 5 existing
+`run_*_job()` methods (download → load → aggregate → generate_summaries → rebuild_embeddings)
+in a single job, reporting combined progress. No new business logic.
+
+**Rationale:**
+
+- Single source of truth for each stage: if any stage changes, full-pipeline benefits
+  automatically.
+- The endpoint does one thing — orchestration — and does it in ~30 lines.
+
+### 9. Where does the seed loader live: `backend/scripts/` vs `backend/app/cli/`?
+
+**Decision:** `backend/scripts/seed_load.py` and `backend/scripts/seed_build.py`.
+
+**Rationale:**
+
+- `backend/app/` is the FastAPI app. Adding CLI entry points there blurs the boundary.
+- `backend/scripts/` is a conventional location for maintenance scripts that import
+  from the app but aren't part of it. Existing repo does not yet have `scripts/`, but
+  this is a clean first entry.
+- Both scripts can still import `from app.services.ingestion_service import IngestionService`
+  as long as they're run from `backend/` (same cwd as pytest).
+
+**Alternative rejected:** `backend/app/cli/seed.py`. Rejected because it suggests the
+CLI is part of the shipped product, when it's a dev/maintainer tool.
+
+### 10. Testing strategy for the new summary stage
+
+**Decision:**
+
+- **Unit tests** (`backend/tests/unit/test_summary_generation.py`):
+  - Mock the OpenAI adapter (`MagicMock(spec=OpenAIAdapter)`).
+  - Mock the DB connection.
+  - Verify: prompt template is loaded, substituted correctly, the chat method is called
+    with the right args, the SQL UPDATE is issued with the correct parameters.
+  - Verify: empty events bucket is skipped with a warning (edge case).
+  - Verify: rate-limit retry logic is exercised (reuse existing adapter retry test
+    pattern).
+
+- **Unit tests** (`backend/tests/unit/test_seed_loader.py`):
+  - Mock filesystem (tmp_path fixture).
+  - Mock repos and ingestion service internals.
+  - Verify: idempotency check (both tables populated → exits 0).
+  - Verify: download failure → exits non-zero with clear error.
+  - Verify: sha256 mismatch → raises.
+
+- **API test** (`backend/tests/api/test_ingestion_full_pipeline.py`):
+  - FastAPI TestClient.
+  - Mock all 5 `run_*_job` methods on the injected service.
+  - POST `/ingestion/full-pipeline` with valid payload, assert all 5 are called in order.
+  - Assert one of them raising propagates as a failed job status.
+
+- **Integration test** (`backend/tests/integration/test_seed_load_live.py`,
+  `@pytest.mark.integration`):
+  - Requires docker-compose stack running.
+  - Downloads the real Release tarball.
+  - Runs seed_load against real Postgres + SQL Server containers.
+  - Asserts matches, events_details, aggregations, summaries, embeddings are all populated.
+  - Asserts running seed_load a second time is a no-op (idempotency).
+  - **Skipped in CI** (no docker stack in GitHub Actions); runs manually via
+    `pytest -m integration` on dev machines.
+
+### 11. OPENAI_KEY: when is it required?
+
+**Decision:** In decreasing order of necessity:
+
+| Flow | Needs `OPENAI_KEY`? |
+|---|---|
+| First-run `post-create` seed load | **NO** (uses pre-computed Release tarball) |
+| `make seed` / `python -m backend.scripts.seed_load` | **NO** (same path) |
+| Dashboard chat / RAG runtime (existing behavior) | **YES** — unchanged |
+| `POST /ingestion/full-pipeline` on a new match | **YES** (summary + embeddings call GPT) |
+| `POST /ingestion/summaries/generate` standalone | **YES** |
+| `POST /ingestion/embeddings/rebuild` standalone | **YES** (existing) |
+| `backend/scripts/seed_build.py` (maintainer) | **YES** — only run when updating the Release |
+
+This satisfies the user's requirement: a new dev can clone, `Reopen in Container`, and
+have a working dashboard **without providing any key**. The chat UI itself, however,
+still needs `OPENAI_KEY` in `.env.docker` to answer questions — that is unchanged from
+today.
+
+## File changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `backend/app/services/prompts/__init__.py` | (new) | Package marker |
+| `backend/app/services/prompts/event_summary.md` | (new) | Prompt template (plain text, `{placeholder}` slots) |
+| `backend/app/services/ingestion_service.py` | (modified) | Add `run_generate_summaries_job()`, `_fetch_aggregation_rows_for_summary()`, `_update_summary_for_row()`, `run_full_pipeline_job()`, loader for the prompt file |
+| `backend/app/api/v1/ingestion.py` | (modified) | Add `POST /ingestion/summaries/generate` and `POST /ingestion/full-pipeline` routes |
+| `backend/app/adapters/openai_client.py` | (modified if needed) | Confirm existing `create_chat_completion()` supports the summary call; add helper only if not |
+| `backend/scripts/__init__.py` | (new) | Package marker |
+| `backend/scripts/seed_load.py` | (new) | Dev-path loader: download tarball, verify sha256, load DBs, update summaries + embeddings. No API calls. |
+| `backend/scripts/seed_build.py` | (new) | Maintainer-path builder: downloads StatsBomb JSON for 2 matches, runs full pipeline against a throwaway DB or in-memory buffers, serializes to tarball, prints sha256 and upload instructions. Requires `OPENAI_KEY`. |
+| `.devcontainer/post-create.sh` | (modified) | Remove 900001 inserts, add call to `python -m backend.scripts.seed_load` |
+| `backend/tests/unit/test_summary_generation.py` | (new) | Unit tests for summary stage |
+| `backend/tests/unit/test_seed_loader.py` | (new) | Unit tests for seed loader |
+| `backend/tests/api/test_ingestion_full_pipeline.py` | (new) | API test for orchestrator |
+| `backend/tests/integration/test_seed_load_live.py` | (new) | `@pytest.mark.integration` end-to-end |
+| `docs/getting-started.md` | (modified) | Add "First run" section and troubleshooting |
+| `data/seed/README.md` | (new) | Explains seed versioning, Release location, license |
+| `CHANGELOG.md` | (modified) | `## [Unreleased]` entries |
+| `docs/conversation_log.md` | (modified) | Session entry |
+
+## Risks / Trade-offs
+
+- **[Risk]** StatsBomb open-data URLs could change or go away. **Mitigation:** the seed
+  tarball bundles `match.json`, `events.json`, `lineups.json` verbatim, so once a
+  Release is published it is self-contained. `seed_build.py` is only needed for updates.
+
+- **[Risk]** Prompt template drift: a maintainer edits `event_summary.md` but forgets
+  to rebuild the Release, so production seed and current template diverge.
+  **Mitigation:** `manifest.json` inside the tarball records the template's sha256 at
+  build time. `seed_load.py` logs a warning if the current template's sha256 doesn't
+  match. Not a hard error — the seed is still valid — but visible.
+
+- **[Risk]** GitHub Release download during post-create adds a network dependency that
+  could fail in restricted networks. **Mitigation:** graceful degrade (clear warning,
+  devcontainer still starts). Also cache the tarball under
+  `~/.cache/rag-challenge-seed/` so subsequent container rebuilds reuse it.
+
+- **[Trade-off]** The seed tarball is hosted on GitHub Releases, so anyone cloning the
+  repo can trigger the download but cannot modify the tarball without repo write access.
+  Acceptable for an educational project.
+
+- **[Risk]** `python -m backend.scripts.seed_load` assumes cwd is the repo root (like
+  pytest does). **Mitigation:** the script uses absolute paths derived from
+  `Path(__file__).resolve()` rather than cwd, so it works from anywhere.
+
+- **[Trade-off]** The integration test `test_seed_load_live.py` downloads a real ~20 MB
+  tarball the first time it runs, which slows local testing. **Mitigation:** marked
+  `@pytest.mark.integration`, skipped by default. Also caches the tarball.
+
+- **[Risk]** `seed_build.py` runs GPT calls which cost money. **Mitigation:** documented
+  cost estimate (~$0.30 total for both matches, summaries + embeddings) and gated
+  behind an explicit `--i-have-budget` flag.
+
+## Rollback strategy
+
+- **If the summary stage has a bug:** revert the PR. The pipeline returns to the pre-change
+  behavior (summary always NULL, embeddings step is effectively a no-op). No data loss.
+
+- **If the seed loader corrupts data:** `seed_load.py` operates only on the 2 seed
+  match_ids. A `DELETE FROM matches WHERE match_id IN (3943043, 3869685)` followed by
+  cascade-deletes from events and aggregations cleans up. Document this in
+  `data/seed/README.md`.
+
+- **If the Release tarball is bad:** publish a new `seed/v2` tag, bump the version
+  string in `seed_load.py`, open a hotfix PR.
+
+## Open questions to resolve during implementation
+
+1. **Prompt wording for the narrative.** First pass is the implementer's choice; a
+   follow-up PR can iterate with `seed_build.py` re-run and `seed/v2` tag. Track as a
+   tuning exercise, not a blocker.
+
+2. **Languages for summaries.** Default `"english"`. Settings already honor
+   `Request.language`, so multi-language seed can be a future enhancement (would need
+   separate tarballs per language or a `language_code` column).
+
+3. **SQL Server aggregation table has fewer embedding columns** (2 vs Postgres's 3).
+   The seed only uses `text-embedding-3-small` which both support, so this is not an
+   issue for this change. Documented for future model additions.

--- a/openspec/changes/seed-initial-dataset/proposal.md
+++ b/openspec/changes/seed-initial-dataset/proposal.md
@@ -1,0 +1,177 @@
+## Why
+
+A new developer who clones RAG-Challenge and runs `docker compose up` (or "Reopen in Container")
+lands on `http://localhost:5173/dashboard` and sees **nothing interesting**. The dashboard shows
+2 connected data sources (postgres, sqlserver) but zero matches, zero events, zero embeddings.
+The semantic search is unusable because:
+
+1. The only seeded row is a placeholder (`match_id=900001`, `{"seed": true}`) in
+   `.devcontainer/post-create.sh:86-149` — no events, no aggregations, no embeddings.
+2. To get real data, the dev must run **4 sequential HTTP calls** against `/api/v1/ingestion/*`
+   (download → load → aggregate → embeddings/rebuild), each as a background job, each requiring
+   an OpenAI key for the embeddings step.
+3. **Critical gap discovered during investigation**: the `aggregate` stage populates
+   `events_details__quarter_minute.summary = NULL` and `.embeddings/rebuild` filters
+   `WHERE summary IS NOT NULL`, so embeddings are **never created** out of the box. A summary
+   generation step (LLM-based narrative per 15-second bucket) is described in
+   `docs/data-model.md:137-139` but **does not exist in code**. This is a silent dead-end in
+   the pipeline.
+
+Result: the project is impossible to evaluate without either (a) understanding the pipeline
+internals and filling the gap manually, or (b) following a long manual setup that consumes
+OpenAI tokens on every fresh clone.
+
+This change fixes all three problems in one coordinated effort. References **issue #40
+(Area 8: Automatic setup and seed data)** as the umbrella, and adds the two canonical finals
+already used across the test suite and proposed in that issue.
+
+## What Changes
+
+### A. Close the summary-generation gap (new pipeline stage)
+
+- Add `POST /api/v1/ingestion/summaries/generate` endpoint that, for a given `source` +
+  `match_ids`, reads rows from `events_details__quarter_minute` (Postgres) or
+  `events_details__15secs_agg` (SQL Server), calls a chat model (GPT-4o-mini by default)
+  with a prompt template converting raw event JSON into football commentary, and UPDATEs the
+  `summary` column row-by-row.
+- Add `IngestionService.run_generate_summaries_job(payload)` as the job handler.
+- Add a prompt template under `backend/app/services/prompts/event_summary.md` (or equivalent
+  — see design.md) that the service loads.
+- Add a `POST /api/v1/ingestion/full-pipeline` endpoint that chains:
+  `download → load → aggregate → generate_summaries → embeddings/rebuild` for a given match list,
+  reporting progress via the existing job-status mechanism.
+
+### B. Seed dataset (2 canonical finals, pre-computed)
+
+- Pre-compute summaries and embeddings **once**, outside the repo, for:
+  1. **Euro 2024 Final** — `competition_id=55`, `season_id=282`, `match_id=3943043`
+     (Spain 2-1 England, 2024-07-14)
+  2. **World Cup 2022 Final** — `competition_id=43`, `season_id=106`, `match_id=3869685`
+     (Argentina 3-3 France, pens. 4-2, 2022-12-18)
+- Publish the pre-computed artifacts as a **GitHub Release asset** (`seed-v1.tar.gz` or similar),
+  NOT committed to the repo. The raw StatsBomb JSON is referenced as public data and downloaded
+  on demand if needed — it is not committed either.
+- Seed file structure (inside the Release tarball):
+  ```
+  seed/
+    v1/
+      manifest.json              # version, matches, embedding model, sha256 per file
+      3943043/
+        match.json               # raw StatsBomb match row (from matches/55/282.json)
+        events.json              # raw StatsBomb events/3943043.json
+        lineups.json              # raw StatsBomb lineups/3943043.json
+        summaries.jsonl          # one row per 15-sec bucket with generated summary
+        embeddings_t3_small.jsonl # one row per bucket with 1536-dim vector
+      3869685/
+        match.json
+        events.json
+        lineups.json
+        summaries.jsonl
+        embeddings_t3_small.jsonl
+  ```
+
+### C. Seed loader (no API calls)
+
+- Add `backend/scripts/seed_load.py` (or `backend/app/cli/seed.py` — see design.md for location)
+  that:
+  1. Downloads the Release tarball if not already present under `backend/data/seed/v1/`.
+  2. Verifies sha256 against `manifest.json`.
+  3. Loads `matches`, `events`, `events_details` using the existing ingestion service's
+     `_load_matches()` / `_load_events()` paths (refactored to accept local JSON, not just
+     `./data/` convention).
+  4. Runs `_build_aggregations()` for the seed match_ids.
+  5. UPDATEs `summary` column from `summaries.jsonl`.
+  6. UPDATEs `summary_embedding_t3_small` column from `embeddings_t3_small.jsonl`.
+  7. **Zero OpenAI calls. Works without OPENAI_KEY.**
+
+### D. Wire seed into first-run experience
+
+- Update `.devcontainer/post-create.sh` to call the seed loader idempotently: if
+  `SELECT COUNT(*) FROM matches WHERE match_id IN (3943043, 3869685)` returns 2 rows with
+  non-null `summary_embedding_t3_small` in their aggregation rows, skip. Otherwise, run the
+  seed loader for both Postgres and SQL Server.
+- Replace the current `match_id=900001` placeholder seed with real data. Keep the 900001 row
+  out of the final seed (dead code, no events, confuses the explorer).
+
+### E. Fallback path for devs who want to regenerate
+
+- Document in `docs/getting-started.md` how to:
+  1. Run the seed loader offline (default path, no key).
+  2. Run the full pipeline against any match_id with a key (`POST /ingestion/full-pipeline`).
+- Add a `backend/scripts/seed_build.py` (maintainer-only, **not** run during dev onboarding)
+  that regenerates the Release tarball from scratch using OPENAI_KEY. This is the script the
+  maintainer runs once, uploads the tarball to a GitHub Release, and bumps the version tag.
+
+### F. Documentation
+
+- `docs/getting-started.md`: "First run" section that describes what the dashboard will show
+  after `Reopen in Container` (2 matches with full RAG).
+- `data/seed/README.md`: explains the seed version scheme, how to regenerate, where the
+  Release is hosted, licensing (StatsBomb open-data CC BY-NC-SA).
+- `CHANGELOG.md` under `## [Unreleased]`.
+
+## Capabilities
+
+### New Capabilities
+
+- **`rag`**: Summary generation pipeline stage that converts aggregated 15-second event
+  buckets into natural-language football commentary using an LLM. Previously missing entirely.
+- **`data`**: Offline seed dataset mechanism — pre-computed summaries + embeddings distributed
+  as a GitHub Release, loaded idempotently on first run without OpenAI API calls.
+
+### Modified Capabilities
+
+- **`api`**: Adds two new ingestion endpoints (`/ingestion/summaries/generate` and
+  `/ingestion/full-pipeline`). No breaking changes to existing endpoints.
+- **`infra`**: `.devcontainer/post-create.sh` replaces the synthetic `match_id=900001` seed
+  with a real idempotent seed loader.
+
+## Impact
+
+- **Affected layers:**
+  - API: new routes in `backend/app/api/v1/ingestion.py`
+  - Service: new methods in `backend/app/services/ingestion_service.py`; new
+    `backend/app/services/prompts/` directory
+  - Adapters: `OpenAIAdapter` gets a new `create_chat_completion_for_summary()` helper
+    (or reuse existing chat method if it already covers this case)
+  - Scripts: `backend/scripts/seed_load.py` (dev-path, no key) and `backend/scripts/seed_build.py`
+    (maintainer-path, needs key)
+  - Infra: `.devcontainer/post-create.sh` rewritten
+  - Docs: `docs/getting-started.md`, `data/seed/README.md`
+
+- **Affected files (estimated):**
+  - Modified: 6 — `backend/app/api/v1/ingestion.py`, `backend/app/services/ingestion_service.py`,
+    `.devcontainer/post-create.sh`, `docs/getting-started.md`, `CHANGELOG.md`, `docs/conversation_log.md`
+  - New: 8 — `backend/app/services/prompts/event_summary.md`,
+    `backend/scripts/seed_load.py`, `backend/scripts/seed_build.py`,
+    `backend/tests/unit/test_summary_generation.py`,
+    `backend/tests/unit/test_seed_loader.py`,
+    `backend/tests/api/test_ingestion_full_pipeline.py`,
+    `data/seed/README.md`,
+    `openspec/changes/seed-initial-dataset/*` (this change)
+
+- **Test impact:**
+  - New unit tests for summary generation (mock OpenAI adapter, verify prompt + SQL update)
+  - New unit tests for seed loader (mock filesystem + mock repos)
+  - New API test for `/ingestion/full-pipeline` orchestration
+  - Integration test (marked `@pytest.mark.integration`) that runs the full seed load
+    against real Docker Postgres + SQL Server — **skipped in CI by default**, runs locally
+    on demand
+
+- **Backwards compatibility:**
+  - **Existing ingestion endpoints unchanged** — no breaking changes.
+  - The `match_id=900001` synthetic seed is removed. Anyone who relied on it would have been
+    relying on empty rows; risk is effectively zero.
+  - `events_details__quarter_minute.summary` becomes populated for seed matches; was NULL
+    before. No schema change.
+
+- **Breaking changes:** None for existing users. The first-run experience of the devcontainer
+  changes (more data appears), but that is the goal of the change.
+
+## References
+
+- GitHub issue: **erincon01/RAG-Challenge#40** (Area 8: Automatic setup and seed data)
+- `docs/PLAN_V5_IMPROVEMENTS.md` — Area 8
+- Existing pre-generated summary previews at `data/scripts_summary/preview/` (only 10 files,
+  manually crafted, for match 3943043 only — will be replaced by the automated pipeline output)
+- StatsBomb open-data license: CC BY-NC-SA 4.0 (non-commercial, attribution required)

--- a/openspec/changes/seed-initial-dataset/tasks.md
+++ b/openspec/changes/seed-initial-dataset/tasks.md
@@ -1,0 +1,228 @@
+## Phase 0 — Prep
+
+- [ ] 0.1 Create branch `feature/040-seed-initial-dataset` from `develop`
+- [ ] 0.2 Read `proposal.md` and `design.md` end-to-end; confirm scope with user if any decision feels wrong
+- [ ] 0.3 Confirm OpenAI key is set in `backend/.env` (or `.env.docker`) for the maintainer-path scripts; verify `OPENAI_PROVIDER`, `OPENAI_ENDPOINT`, `OPENAI_KEY`, `OPENAI_MODEL` are loaded correctly
+- [ ] 0.4 Verify StatsBomb open-data URLs are reachable:
+  `curl -I https://raw.githubusercontent.com/statsbomb/open-data/master/data/events/3943043.json`
+  `curl -I https://raw.githubusercontent.com/statsbomb/open-data/master/data/events/3869685.json`
+
+## Phase 1 — Summary generation stage (closes the pipeline gap)
+
+### 1.1 Prompt template
+
+- [ ] 1.1.1 Create `backend/app/services/prompts/__init__.py` (empty)
+- [ ] 1.1.2 Create `backend/app/services/prompts/event_summary.md` with a first-pass prompt:
+  slots `{match_info}`, `{period}`, `{minute}`, `{second_window}`, `{events_json}`, `{language}`
+  — output contract: 1-3 sentence plain-text narrative, no markdown headers
+- [ ] 1.1.3 Write unit test `test_event_summary_prompt_loads_from_file` that opens the file,
+  runs `str.format()` with fake slots, asserts no `KeyError` and output length > 0
+
+### 1.2 Ingestion service changes
+
+- [ ] 1.2.1 Add private method `_load_prompt_template()` to `IngestionService` that reads
+  `backend/app/services/prompts/event_summary.md` at init time and caches the content
+- [ ] 1.2.2 Add private method `_fetch_aggregation_rows_for_summary(conn, source, match_ids)`
+  returning rows with `id`, `period`, `minute`, `quarter_minute`, `json_` (the raw events
+  JSON from the `GROUP BY` string_agg) from the aggregation table where `summary IS NULL`
+  for the given match_ids
+- [ ] 1.2.3 Add private method `_update_summary_for_row(conn, source, row_id, summary)`
+  that issues the UPDATE with parameterized query (`%s` / `?`)
+- [ ] 1.2.4 Add public method `run_generate_summaries_job(payload, job)` that:
+  (a) opens a connection for the given source,
+  (b) loads match metadata (home/away team, competition, date) once per match_id for prompt context,
+  (c) iterates rows from `_fetch_aggregation_rows_for_summary`,
+  (d) for each row, builds the prompt via `str.format()`, calls `OpenAIAdapter.create_chat_completion()`,
+  (e) strips the response, calls `_update_summary_for_row`,
+  (f) updates `job.progress` every N rows,
+  (g) handles rate-limit errors via the existing retry logic in the adapter,
+  (h) commits the transaction at the end
+- [ ] 1.2.5 Write unit test `test_generate_summaries_job_happy_path` — mock adapter, mock connection,
+  verify prompt is built, chat is called once per row, UPDATE is issued with the response
+- [ ] 1.2.6 Write unit test `test_generate_summaries_job_skips_empty_buckets` — row with empty
+  `json_` should be skipped and logged, no chat call
+- [ ] 1.2.7 Write unit test `test_generate_summaries_job_continues_on_partial_failure` — one
+  row raises, next row still processes
+- [ ] 1.2.8 Run pytest on the new test file; confirm all pass and imports resolve from `backend/`
+
+### 1.3 API endpoint
+
+- [ ] 1.3.1 Add `POST /api/v1/ingestion/summaries/generate` route in `backend/app/api/v1/ingestion.py`
+  accepting `{source: "postgres"|"sqlserver", match_ids: list[int]}`, returning job_id
+- [ ] 1.3.2 Wire the route to a background task that calls `run_generate_summaries_job`
+- [ ] 1.3.3 Write API test `test_post_summaries_generate_returns_job_id` — mock service,
+  POST with valid payload, assert 202 and job_id in response
+- [ ] 1.3.4 Write API test `test_post_summaries_generate_rejects_invalid_source` — POST with
+  `source="mongo"`, assert 422 or 400
+- [ ] 1.3.5 Write API test `test_post_summaries_generate_empty_match_ids_rejected` — POST with
+  `match_ids=[]`, assert validation error
+- [ ] 1.3.6 Run pytest on the API test file; confirm all pass
+
+## Phase 2 — Full-pipeline orchestrator endpoint
+
+- [ ] 2.1 Add public method `run_full_pipeline_job(payload, job)` to `IngestionService` that
+  sequentially invokes `run_download_job`, `run_load_job`, `run_aggregate_job`,
+  `run_generate_summaries_job`, `run_rebuild_embeddings_job` with shared job progress tracking
+- [ ] 2.2 Add `POST /api/v1/ingestion/full-pipeline` route accepting the union of all stage
+  payloads (source, match_ids, competition_id, season_id, embedding_models optional)
+- [ ] 2.3 Write unit test `test_run_full_pipeline_calls_stages_in_order` — mock each stage,
+  assert call order and that a failure in stage N aborts stages N+1..5
+- [ ] 2.4 Write API test `test_post_full_pipeline_happy_path` — mock service, POST, assert
+  202 + job_id
+- [ ] 2.5 Run pytest; confirm all pass
+
+## Phase 3 — Maintainer script (seed_build.py)
+
+- [ ] 3.1 Create `backend/scripts/__init__.py` (empty)
+- [ ] 3.2 Create `backend/scripts/seed_build.py` with argparse flags `--i-have-budget`,
+  `--output <path>`, `--matches 3943043,3869685`
+- [ ] 3.3 Implement download step: call `StatsBombService.download_match_file()` for
+  `matches`, `events`, `lineups` datasets for each match_id, into a temp directory
+- [ ] 3.4 Implement DB step: spin up a throwaway Postgres (or reuse the local one with a
+  temp schema), run `_load_matches`, `_load_events`, `_build_aggregations` for the seed
+  match_ids — OR — skip the DB and go straight to in-memory processing (decision during
+  implementation; whichever is simpler)
+- [ ] 3.5 Implement summary generation step: iterate buckets, call the summary prompt +
+  GPT-4o-mini, write to `summaries.jsonl` (one `{bucket_id, summary}` per line)
+- [ ] 3.6 Implement embedding step: iterate `summaries.jsonl`, call
+  `OpenAIAdapter.create_embedding()` batched 50, write to
+  `embeddings_t3_small.jsonl` (one `{bucket_id, vector}` per line)
+- [ ] 3.7 Assemble tarball `seed-v1.tar.gz` with the structure in proposal.md §B
+- [ ] 3.8 Compute sha256 for each file, write `manifest.json`
+- [ ] 3.9 Print upload instructions: `gh release create seed/v1 ./seed-v1.tar.gz --notes "..."`
+- [ ] 3.10 **MANUAL:** maintainer runs `python -m backend.scripts.seed_build --i-have-budget`
+  once, reviews output, runs the `gh release create` command, confirms the asset is
+  downloadable at `https://github.com/erincon01/RAG-Challenge/releases/download/seed/v1/seed-v1.tar.gz`
+- [ ] 3.11 Write unit test `test_seed_build_refuses_without_budget_flag` — argparse test,
+  no OpenAI calls
+- [ ] 3.12 Run ruff + pytest on scripts changes
+
+## Phase 4 — Dev-path script (seed_load.py)
+
+- [ ] 4.1 Create `backend/scripts/seed_load.py` with hardcoded constants:
+  - `SEED_VERSION = "v1"`
+  - `SEED_URL = "https://github.com/erincon01/RAG-Challenge/releases/download/seed/v1/seed-v1.tar.gz"`
+  - `SEED_MATCH_IDS = (3943043, 3869685)`
+  - `CACHE_DIR = Path.home() / ".cache" / "rag-challenge-seed"`
+- [ ] 4.2 Implement `check_idempotency(source)` that returns True if both match_ids exist
+  AND have non-null `summary_embedding_t3_small` in their aggregation rows
+- [ ] 4.3 Implement `download_and_verify(url, cache_dir)` that downloads the tarball if not
+  cached, extracts to a temp dir, verifies sha256s against manifest.json, returns the
+  extracted path
+- [ ] 4.4 Implement `load_into(source, seed_path)`:
+  - Read `match.json` files → `_load_matches` (internal API)
+  - Read `events.json` files → `_load_events`
+  - Call `_build_aggregations` for seed match_ids
+  - Read `summaries.jsonl` → UPDATE `summary` by bucket_id
+  - Read `embeddings_t3_small.jsonl` → UPDATE `summary_embedding_t3_small` by bucket_id
+- [ ] 4.5 Add main entry point supporting `--source postgres` / `--source sqlserver` /
+  `--source both` (default: `both`)
+- [ ] 4.6 On any failure, print clear error to stderr, exit non-zero; do NOT raise unhandled
+  exceptions (post-create must continue even on failure)
+- [ ] 4.7 Write unit test `test_seed_load_idempotent_when_data_present` — mock repos,
+  check_idempotency returns True → script exits 0 without touching files
+- [ ] 4.8 Write unit test `test_seed_load_downloads_and_loads_when_data_missing` — mock repos,
+  check_idempotency returns False → script calls download + load in order
+- [ ] 4.9 Write unit test `test_seed_load_sha256_mismatch_aborts` — mock manifest with wrong
+  hash → script raises and exits non-zero
+- [ ] 4.10 Write unit test `test_seed_load_download_failure_graceful` — mock network error →
+  script logs warning and exits non-zero, no partial state in DB
+- [ ] 4.11 Run pytest and confirm all unit tests pass
+
+## Phase 5 — Wire into post-create
+
+- [ ] 5.1 Modify `.devcontainer/post-create.sh`:
+  - Remove the `INSERT INTO matches ... 900001 ...` blocks for both Postgres and SQL Server
+  - After the `wait_for_db` section, add a call:
+    ```bash
+    echo "[post-create] Loading seed dataset..."
+    python -m backend.scripts.seed_load --source both || {
+      echo "  [warn] Seed load failed — dashboard will be empty, you can retry with 'make seed' or 'python -m backend.scripts.seed_load'"
+    }
+    ```
+- [ ] 5.2 Verify post-create.sh still parses with `bash -n .devcontainer/post-create.sh`
+- [ ] 5.3 Add a `Makefile` (or append to existing one — check repo root first) with a target:
+  ```makefile
+  seed:
+  	@cd backend && python -m scripts.seed_load --source both
+  ```
+- [ ] 5.4 **DEFERRED: requires docker on user host** — Rebuild the devcontainer and verify:
+  - `docker compose exec backend python -c "from app.repositories... ; print(count)"`
+    shows 2 matches, ~5000 aggregation rows, ~5000 non-null summaries, ~5000 non-null
+    `summary_embedding_t3_small` values
+  - Dashboard at `http://localhost:5173/dashboard` shows both matches in the explorer
+  - Chat page can ask "¿Quién marcó el primer gol de la final?" and get a relevant answer
+
+## Phase 6 — Documentation
+
+- [ ] 6.1 Create `data/seed/README.md` explaining:
+  - What the seed contains (2 matches)
+  - License (StatsBomb CC BY-NC-SA 4.0, attribution text)
+  - Where the tarball lives (GitHub Release URL)
+  - How to regenerate (`python -m backend.scripts.seed_build --i-have-budget`)
+  - How to clean local seed cache (`rm -rf ~/.cache/rag-challenge-seed`)
+  - How to remove seed data from DB
+- [ ] 6.2 Update `docs/getting-started.md`:
+  - Add "First run" section describing what the dashboard shows after `Reopen in Container`
+  - Add troubleshooting section: what to do if seed load failed
+  - Mention that the chat UI requires `OPENAI_KEY` in `.env.docker` (unchanged)
+- [ ] 6.3 Update `CHANGELOG.md` under `## [Unreleased]`:
+  - **Added**: automatic seed dataset (2 finals), new ingestion stages (summaries, full-pipeline)
+  - **Changed**: devcontainer first-run loads real data instead of placeholder
+  - **Removed**: synthetic `match_id=900001` placeholder
+- [ ] 6.4 Append session entry to `docs/conversation_log.md`
+
+## Phase 7 — Integration test
+
+- [ ] 7.1 Create `backend/tests/integration/test_seed_load_live.py` with
+  `@pytest.mark.integration` decorator
+- [ ] 7.2 Test `test_seed_load_populates_postgres_and_sqlserver` — requires running
+  docker-compose stack; cleans the 2 match_ids, runs `seed_load.py`, asserts counts and
+  non-null summaries/embeddings
+- [ ] 7.3 Test `test_seed_load_second_run_is_noop` — runs `seed_load.py` twice, asserts
+  second run exits 0 in < 2 seconds and makes no DB writes
+- [ ] 7.4 Document in the test file how to run: `pytest -m integration backend/tests/integration/`
+- [ ] 7.5 Confirm integration tests are excluded from default CI by checking `pytest.ini`
+
+## Phase 8 — Final verification
+
+- [ ] 8.1 Run `pytest backend/tests/ -v` (excluding integration) — all 470+ tests + new tests must pass
+- [ ] 8.2 Run `pytest -m integration backend/tests/integration/` on local docker stack — must pass
+- [ ] 8.3 Run `ruff check backend/` and `ruff format --check backend/`
+- [ ] 8.4 Run `mypy backend/app` — no new errors introduced
+- [ ] 8.5 From a clean devcontainer rebuild, verify the dashboard shows both matches and the
+  chat UI can answer questions about them (requires `OPENAI_KEY`)
+
+## Phase 9 — Commit & PR
+
+- [ ] 9.1 Stage all new and modified files
+- [ ] 9.2 Commit in logical chunks (one commit per phase if clean, or a single squashable PR):
+  - `feat(ingestion): add summary generation stage`
+  - `feat(ingestion): add full-pipeline orchestrator endpoint`
+  - `feat(seed): add seed_load and seed_build scripts`
+  - `chore(devcontainer): replace placeholder seed with automatic seed load`
+  - `docs: document seed dataset and first-run experience`
+- [ ] 9.3 Push branch, open PR against `develop`, link issue #40 in the body
+- [ ] 9.4 Request review, iterate, merge
+- [ ] 9.5 After merge, run `/opsx:archive seed-initial-dataset`
+- [ ] 9.6 After merge, close issue #40 (or leave open if this is only phase 1 of 40's broader scope)
+
+---
+
+### Verification rules
+
+- **Never mark a task `[x]` without running the verification it implies.** Especially:
+  - Phase 1 tasks require pytest to pass on the new tests before being marked.
+  - Phase 5.4 requires docker and is DEFERRED to the user or a host with docker access.
+  - Phase 7 requires docker and is DEFERRED.
+  - Phase 3.10 involves publishing to GitHub Releases and requires maintainer approval.
+
+- **Summaries are expensive.** The first successful run of `seed_build.py` generates
+  ~5000 chat completions. Estimate ~$0.30 with GPT-4o-mini. Do not iterate on the prompt
+  in a loop without reviewing costs.
+
+- **Test runner cwd.** All pytest commands must run from `backend/` so that
+  `from app.services...` imports resolve correctly.
+
+- **TDD rule.** Write the failing test first, then the implementation, then verify green.
+  Do not skip the failing-test step.


### PR DESCRIPTION
## Summary

Resolves the first-run friction described in issue #40: after cloning + `Reopen in Container`, the dashboard is populated with two iconic finals and the RAG pipeline works end-to-end **without requiring an OpenAI key at setup time**.

On the way, this PR closes a **critical silent gap** in the ingestion pipeline that prevented embeddings from ever being created.

## The hidden bug fixed in this PR

Before this change: the `aggregate` stage wrote `events_details__quarter_minute.summary = NULL`, and the `embeddings/rebuild` stage filtered `WHERE summary IS NOT NULL`. **No row ever qualified**. The 4-stage pipeline described in `docs/data-model.md` was a 3-stage + dead-end.

- [backend/app/services/ingestion_service.py:666-675](https://github.com/erincon01/RAG-Challenge/blob/develop/backend/app/services/ingestion_service.py#L666-L675) — where `summary = NULL` was written
- [backend/app/services/ingestion_service.py:458-489](https://github.com/erincon01/RAG-Challenge/blob/develop/backend/app/services/ingestion_service.py#L458-L489) — where `summary IS NOT NULL` filtered the results to zero

This PR adds the missing **5th stage**: LLM-generated narrative summaries per 15-second bucket.

## What changes

### 1. New pipeline stage: summary generation

- `POST /api/v1/ingestion/summaries/generate` — dedicated endpoint
- `IngestionService.run_generate_summaries_job()` — builds a prompt per bucket from `backend/app/services/prompts/event_summary.md`, calls the chat model, strips and UPDATEs the row. Resumable (only processes rows with `summary IS NULL`), tolerant to per-row failures.

### 2. Full-pipeline orchestrator

- `POST /api/v1/ingestion/full-pipeline` — sequentially runs `download → load → aggregate → summaries → embeddings` with shared job progress. Aborts on any stage failure.

### 3. Seed dataset (two canonical finals)

| Match | Competition | match_id |
|---|---|---|
| Spain 2-1 England | UEFA Euro 2024 Final | 3943043 |
| Argentina 3-3 France (pens. 4-2) | FIFA World Cup 2022 Final | 3869685 |

Both finals already used as canonical test fixtures in `conftest.py`. This PR makes them also the seed dataset.

### 4. Seed loader (`backend/scripts/seed_load.py`)

Runs during `.devcontainer/post-create.sh` on first open. Idempotent, downloads a pre-computed tarball from a GitHub Release, verifies sha256, loads into both Postgres and SQL Server. **Zero OpenAI calls** — summaries and embeddings are pre-computed.

### 5. Seed builder (`backend/scripts/seed_build.py`)

Maintainer-only script that runs the full pipeline against the local Docker stack, exports rows to the tarball format, and prints `gh release create` instructions. Requires `--i-have-budget` flag and `OPENAI_KEY` (~\$0.30 total cost).

### 6. Devcontainer wiring

`.devcontainer/post-create.sh` — removed the `match_id=900001` synthetic placeholder and replaced with an idempotent call to `scripts.seed_load`.

### 7. Makefile + docs

- Root `Makefile` with `seed`, `seed-force`, `seed-postgres`, `seed-sqlserver`, `test`, `lint`, `format`.
- `docs/getting-started.md` — new "First run — seed dataset" section.
- `data/seed/README.md` — full documentation of the seed, licensing, regeneration process.

## Commits (logical chunks)

1. `feat(ingestion): add summary generation stage and full-pipeline orchestrator`
2. `feat(scripts): add seed_load and seed_build with unit tests`
3. `chore(devcontainer): replace placeholder seed with automatic seed loader`
4. `docs: document seed dataset and first-run experience`

## Test plan

### Done in this PR
- [x] 530 backend tests passing (was 470). 60+ new unit tests across summary generation, full-pipeline orchestrator, seed_build, seed_load, plus 13 new API tests.
- [x] `ruff check backend/app backend/scripts` — clean
- [x] `ruff format --check backend/app backend/scripts` — clean
- [x] Total coverage 83% (CI threshold 80%)
- [x] `bash -n .devcontainer/post-create.sh` — syntax valid
- [x] Integration tests (`test_seed_load_live.py`) implemented with `@pytest.mark.integration` + autouse skip fixture that checks the GitHub Release URL before running. Excluded from default `pytest` via `addopts = -m "not integration"`.

### Deferred to the user / maintainer

**Before this PR delivers value, the maintainer must publish the seed tarball once.** Until then, `seed_load.py` will log a 404 warning and the post-create script will continue gracefully. Steps:

1. **Set OpenAI key in `backend/.env` or `.env.docker`** (gitignored — never committed).
2. **Build the tarball** (costs ~\$0.30):
   ```bash
   docker compose up -d
   cd backend
   python -m scripts.seed_build --i-have-budget --output ../seed-v1.tar.gz
   ```
3. **Publish the Release**:
   ```bash
   gh release create seed/v1 ../seed-v1.tar.gz \
     --title "Seed dataset v1" \
     --notes "Pre-computed summaries and embeddings for Euro 2024 + WC 2022 finals."
   ```
4. **Verify the download works from a fresh devcontainer**:
   ```bash
   rm -rf ~/.cache/rag-challenge-seed
   make seed
   # Expected: both matches in the dashboard explorer, chat answers questions.
   ```
5. **Run the integration tests**:
   ```bash
   cd backend && pytest -m integration tests/integration/test_seed_load_live.py -v
   ```

### Deferred (frontend UX — out of scope)

The "Data Sources" label on the dashboard currently means "database backends" (postgres + sqlserver), not "datasets". This was confusing when the issue was first raised. **This PR does not touch that label** — it belongs in a separate frontend UX ticket.

## Files changed

Modified: 6 — `backend/app/api/v1/ingestion.py`, `backend/app/services/ingestion_service.py`, `backend/pytest.ini`, `.devcontainer/post-create.sh`, `CHANGELOG.md`, `docs/conversation_log.md`, `docs/getting-started.md`, `backend/tests/api/test_ingestion.py`

New: 12 — `backend/app/services/prompts/__init__.py`, `backend/app/services/prompts/event_summary.md`, `backend/scripts/__init__.py`, `backend/scripts/seed_build.py`, `backend/scripts/seed_load.py`, `backend/tests/unit/test_summary_generation.py`, `backend/tests/unit/test_full_pipeline_orchestrator.py`, `backend/tests/unit/test_seed_build.py`, `backend/tests/unit/test_seed_load.py`, `backend/tests/integration/test_seed_load_live.py`, `data/seed/README.md`, `Makefile`, `openspec/changes/seed-initial-dataset/{proposal,design,tasks}.md`

## Rollback

Revert the 4 commits in order. The change is additive for the pipeline (new stage, new endpoints, new scripts) and removes one unused synthetic row from post-create. No schema changes, no data loss path.

## References

- Closes-part-of: #40 (Area 8: Automatic setup and seed data)
- OpenSpec change: `openspec/changes/seed-initial-dataset/`