### PR TITLE
feat(skills): add git-workflow, changelog, and e2e-playwright skills

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: changelog
+description: Update CHANGELOG.md with recent changes following Keep a Changelog format. Use this when adding features, fixing bugs, or before creating a release.
+---
+
+# Changelog
+
+Update CHANGELOG.md following Keep a Changelog format.
+
+## When to use this skill
+
+- After implementing a feature or fix (before creating PR)
+- After merging multiple OpenSpec changes
+- Before creating a release tag
+
+## Format
+
+Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
+
+```markdown
+## [Unreleased]
+
+### Added
+- New features, capabilities, endpoints
+
+### Changed
+- Modifications to existing behavior, refactors
+
+### Fixed
+- Bug fixes, corrections
+
+### Removed
+- Removed features, deprecated code
+
+### Security
+- Security hardening, vulnerability fixes
+```
+
+## Procedure
+
+### Adding entries for a PR
+
+1. Read the current `CHANGELOG.md`
+2. Add entry under `## [Unreleased]` in the appropriate section
+3. Use concise descriptions referencing the PR number if available
+4. Group related changes together
+
+Example:
+```markdown
+### Added
+- Token budget guard for RAG pipeline — truncates context when over budget (#19)
+- `CORS_ORIGINS` env var for configurable CORS origins (#16)
+
+### Changed
+- DataExplorerService refactored to use Repository Pattern (#17)
+
+### Security
+- Replaced `allow_origins=["*"]` with configurable CORS origins (#16)
+```
+
+### Creating a release
+
+When the user wants to tag a release:
+
+1. Move `[Unreleased]` content to a new version section `[X.Y.Z] - YYYY-MM-DD`
+2. Create empty `[Unreleased]` section
+3. Update version in `backend/app/main.py`, `README.md`, `PROJECT_STATUS.md`
+4. Versioning:
+   - **MAJOR**: breaking API changes
+   - **MINOR**: new features, backwards-compatible
+   - **PATCH**: bug fixes
+
+## Rules
+
+- ALWAYS write entries in English
+- ALWAYS include PR number when available: `(#NN)`
+- ALWAYS use ISO dates (YYYY-MM-DD)
+- NEVER remove existing entries
+- NEVER skip CHANGELOG update in code PRs (docs-only PRs may skip with justification)
+- Group entries by type (Added, Changed, Fixed, etc.) — not by PR or date

--- a/.claude/skills/e2e-playwright/SKILL.md
+++ b/.claude/skills/e2e-playwright/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: e2e-playwright
+description: Tests end-to-end con Playwright para el frontend React. Ejecutar tests E2E, crear tests nuevos, generar capturas.
+argument-hint: <action> [arguments]
+---
+
+# E2E Testing con Playwright
+
+El usuario ha invocado `/e2e` con los argumentos: $ARGUMENTS
+
+Actua como experto en Playwright para TypeScript/React. El proyecto usa un frontend React 18 + TypeScript + Vite corriendo en Docker Compose.
+
+**Acciones disponibles:**
+- `run` — Ejecutar todos los tests E2E
+- `run <page>` — Ejecutar tests de una pagina (home, dashboard, catalog, operations, explorer, embeddings, chat)
+- `screenshots` — Generar capturas de todas las paginas
+- `new <page> <descripcion>` — Crear un test E2E nuevo
+- `status` — Verificar que los containers estan running y healthy
+- `help` — Mostrar esta ayuda
+
+---
+
+## Prerequisitos
+
+Los containers de backend + frontend + bases de datos DEBEN estar corriendo:
+
+```bash
+docker compose up --build -d
+# Frontend: http://localhost:5173
+# Backend: http://localhost:8000
+```
+
+---
+
+## Stack E2E
+
+- **Playwright** for TypeScript (via `npx playwright`)
+- **Test location:** `frontend/webapp/tests/e2e/`
+- **Config:** `frontend/webapp/playwright.config.ts`
+
+---
+
+## Comandos
+
+```bash
+# 1. Levantar servicios (si no estan)
+docker compose up --build -d
+
+# 2. Instalar Playwright (primera vez)
+cd frontend/webapp && npx playwright install --with-deps chromium
+
+# 3. Ejecutar todos los E2E
+cd frontend/webapp && npx playwright test
+
+# 4. Ejecutar tests de una pagina
+cd frontend/webapp && npx playwright test tests/e2e/test_catalog.spec.ts
+
+# 5. Ejecutar con UI mode (debug)
+cd frontend/webapp && npx playwright test --ui
+
+# 6. Generar capturas
+cd frontend/webapp && npx playwright test --update-snapshots
+```
+
+---
+
+## Estructura
+
+```
+frontend/webapp/
+  tests/e2e/
+    home.spec.ts          Home page
+    dashboard.spec.ts     Dashboard: health, DB status, jobs
+    catalog.spec.ts       Catalog: competitions, matches
+    operations.spec.ts    Operations: download, load, process
+    explorer.spec.ts      Explorer: teams, players, events
+    embeddings.spec.ts    Embeddings: coverage, rebuild
+    chat.spec.ts          Chat: RAG semantic search
+  playwright.config.ts    Config: baseURL, timeouts, projects
+```
+
+---
+
+## Selectores preferidos
+
+```typescript
+page.getByRole('button', { name: 'Download' })    // Por rol (mejor)
+page.getByText('Total Matches')                     // Por texto
+page.getByLabel('Source')                            // Por label
+page.getByTestId('sidebar')                          // Por test-id
+```
+
+---
+
+## Plantilla para test nuevo
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('<Page> Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/<route>');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('loads without errors', async ({ page }) => {
+    await expect(page.getByRole('heading')).toBeVisible();
+    await expect(page.locator('text=Error')).toHaveCount(0);
+  });
+
+  test('main content visible', async ({ page }) => {
+    await expect(page.getByText('<expected text>')).toBeVisible();
+  });
+});
+```
+
+---
+
+## Reglas
+
+- **NUNCA** usar `page.waitForTimeout()` — usar `waitForLoadState` o `waitForSelector`
+- **SIEMPRE** usar selectores semánticos (role, text, label) sobre CSS selectors
+- Tests deben ser independientes — no depender del orden de ejecución
+- Cada test debe limpiar su estado si modifica datos
+- Capturas van en `frontend/webapp/tests/e2e/screenshots/`
+
+---
+
+## Comportamiento por accion
+
+### `run`
+1. Verificar containers healthy: `docker compose ps`
+2. Ejecutar: `cd frontend/webapp && npx playwright test`
+
+### `screenshots`
+1. Verificar containers healthy
+2. Ejecutar tests con `--update-snapshots`
+3. Listar capturas generadas
+
+### `new <page> <descripcion>`
+1. Generar test siguiendo plantilla y convenciones del proyecto
+2. Ejecutar para verificar que pasa
+
+### `status`
+1. `docker compose ps` — verificar servicios
+2. `curl http://localhost:8000/api/v1/health/live` — backend health
+3. `curl http://localhost:5173` — frontend health

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: git-workflow
+description: Git workflow for RAG-Challenge. Branch model with develop (integration) and main (production). Use this when creating branches, committing, pushing, or opening PRs.
+---
+
+# Git Workflow
+
+Git workflow for RAG-Challenge. Uses a **simplified GitFlow** with `develop` (integration) and `main` (production).
+
+## Rules
+
+- **Never push directly to `main` or `develop`** — all changes via feature branch + PR
+- **Conventional Commits** format in English: `type(scope): description`
+- **No AI attribution** in commits or PRs (`Co-Authored-By`, `Generated with`, etc.)
+- **Never force push**
+- **Always update CHANGELOG.md** under `## [Unreleased]` in code PRs
+
+## Branch naming
+
+```
+feature/NNN-description   # New functionality (from develop)
+fix/NNN-description       # Bug fixes (from develop)
+hotfix/NNN-description    # Urgent production fixes (from main)
+chore/description         # Maintenance, tooling, config (from develop)
+refactor/description      # Restructure without behavior change (from develop)
+```
+
+`NNN` = zero-padded sequence number (e.g., `016`, `040`). Get next available from repo.
+
+## Commit types
+
+| Type | When |
+|------|------|
+| `feat(scope)` | New functionality |
+| `fix(scope)` | Bug fix |
+| `docs` | Documentation only |
+| `test(scope)` | Adding or updating tests |
+| `chore(scope)` | Maintenance, CI/CD, dependencies |
+| `refactor(scope)` | Restructure without behavior change |
+| `style` | Formatting only |
+| `perf(scope)` | Performance improvement |
+
+## Workflow for a feature/fix
+
+```bash
+# 1. Start from develop
+git checkout develop && git pull origin develop
+
+# 2. Create branch
+git checkout -b feature/NNN-description
+
+# 3. Work (TDD: tests first, then implementation)
+# ... make changes ...
+
+# 4. Stage and commit
+git add <specific-files>
+git commit -m "feat(scope): description"
+
+# 5. Push
+git push -u origin feature/NNN-description
+
+# 6. Create PR → develop
+gh pr create --base develop --title "feat(scope): description" --body "..."
+
+# 7. After CI green + review → merge (squash if many commits)
+# 8. Delete branch after merge
+```
+
+## OpenSpec integration
+
+For non-trivial changes, use the OpenSpec workflow first:
+
+1. `/opsx:propose <change-name>` — creates proposal, design, specs, tasks
+2. Create branch: `git checkout -b feature/NNN-description`
+3. `/opsx:apply` — implements tasks with TDD
+4. Push, PR, merge
+5. `/opsx:archive` — archives completed change
+
+## PR checklist
+
+- [ ] Branch naming follows `<type>/NNN-description`
+- [ ] Conventional Commits in English
+- [ ] Tests pass: `cd backend && pytest tests/ -v`
+- [ ] Coverage >= 80%
+- [ ] Lint clean: `ruff check backend/app && ruff format --check backend/app`
+- [ ] Type check: `mypy backend/app`
+- [ ] CHANGELOG.md updated under `## [Unreleased]`
+- [ ] `docs/conversation_log.md` updated if AI-assisted session
+
+## Releases
+
+- PR `develop → main` with title `release: vX.Y.Z`
+- Follow Semantic Versioning (MAJOR.MINOR.PATCH)
+- Tag on main after merge: `git tag vX.Y.Z && git push origin vX.Y.Z`
+- Promote `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD` in CHANGELOG

--- a/.github/prompts/changelog.prompt.md
+++ b/.github/prompts/changelog.prompt.md
@@ -1,0 +1,12 @@
+---
+description: Update CHANGELOG.md following Keep a Changelog format
+---
+
+Update `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/) format.
+
+1. Read the current CHANGELOG.md
+2. Add entries under `## [Unreleased]` in the correct section (Added, Changed, Fixed, Removed, Security)
+3. Write in English, include PR number `(#NN)` when available
+4. Never remove existing entries
+
+See `.claude/skills/changelog/SKILL.md` for full rules.

--- a/.github/prompts/e2e-playwright.prompt.md
+++ b/.github/prompts/e2e-playwright.prompt.md
@@ -1,0 +1,13 @@
+---
+description: E2E tests with Playwright for the React frontend
+---
+
+Run or create Playwright E2E tests for the React TypeScript frontend.
+
+**Actions:** `run`, `run <page>`, `screenshots`, `new <page> <desc>`, `status`, `help`
+
+**Prerequisites:** Docker Compose services must be running (`docker compose up --build -d`).
+
+**Test location:** `frontend/webapp/tests/e2e/`
+
+See `.claude/skills/e2e-playwright/SKILL.md` for full commands and templates.

--- a/.github/prompts/git-workflow.prompt.md
+++ b/.github/prompts/git-workflow.prompt.md
@@ -1,0 +1,15 @@
+---
+description: Git workflow — create branches, commit, push, open PRs following project conventions
+---
+
+Follow the RAG-Challenge git workflow:
+
+- **Branch from `develop`**: `feature/NNN-desc`, `fix/NNN-desc`, `chore/desc`
+- **Conventional Commits** in English: `type(scope): description`
+- **No AI attribution** (`Co-Authored-By`, `Generated with`, etc.)
+- **PR to `develop`**, never push directly to `main` or `develop`
+- **Update CHANGELOG.md** under `[Unreleased]` in every code PR
+- **Update `docs/conversation_log.md`** if AI-assisted session
+
+See `.github/instructions/git-workflow.instructions.md` for full rules.
+See `AGENTS.md` for project conventions.

--- a/.github/skills/changelog/SKILL.md
+++ b/.github/skills/changelog/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: changelog
+description: Update CHANGELOG.md with recent changes following Keep a Changelog format. Use this when adding features, fixing bugs, or before creating a release.
+---
+
+# Changelog
+
+Update CHANGELOG.md following Keep a Changelog format.
+
+## When to use this skill
+
+- After implementing a feature or fix (before creating PR)
+- After merging multiple OpenSpec changes
+- Before creating a release tag
+
+## Format
+
+Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
+
+```markdown
+## [Unreleased]
+
+### Added
+- New features, capabilities, endpoints
+
+### Changed
+- Modifications to existing behavior, refactors
+
+### Fixed
+- Bug fixes, corrections
+
+### Removed
+- Removed features, deprecated code
+
+### Security
+- Security hardening, vulnerability fixes
+```
+
+## Procedure
+
+### Adding entries for a PR
+
+1. Read the current `CHANGELOG.md`
+2. Add entry under `## [Unreleased]` in the appropriate section
+3. Use concise descriptions referencing the PR number if available
+4. Group related changes together
+
+Example:
+```markdown
+### Added
+- Token budget guard for RAG pipeline — truncates context when over budget (#19)
+- `CORS_ORIGINS` env var for configurable CORS origins (#16)
+
+### Changed
+- DataExplorerService refactored to use Repository Pattern (#17)
+
+### Security
+- Replaced `allow_origins=["*"]` with configurable CORS origins (#16)
+```
+
+### Creating a release
+
+When the user wants to tag a release:
+
+1. Move `[Unreleased]` content to a new version section `[X.Y.Z] - YYYY-MM-DD`
+2. Create empty `[Unreleased]` section
+3. Update version in `backend/app/main.py`, `README.md`, `PROJECT_STATUS.md`
+4. Versioning:
+   - **MAJOR**: breaking API changes
+   - **MINOR**: new features, backwards-compatible
+   - **PATCH**: bug fixes
+
+## Rules
+
+- ALWAYS write entries in English
+- ALWAYS include PR number when available: `(#NN)`
+- ALWAYS use ISO dates (YYYY-MM-DD)
+- NEVER remove existing entries
+- NEVER skip CHANGELOG update in code PRs (docs-only PRs may skip with justification)
+- Group entries by type (Added, Changed, Fixed, etc.) — not by PR or date

--- a/.github/skills/e2e-playwright/SKILL.md
+++ b/.github/skills/e2e-playwright/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: e2e-playwright
+description: Tests end-to-end con Playwright para el frontend React. Ejecutar tests E2E, crear tests nuevos, generar capturas.
+argument-hint: <action> [arguments]
+---
+
+# E2E Testing con Playwright
+
+El usuario ha invocado `/e2e` con los argumentos: $ARGUMENTS
+
+Actua como experto en Playwright para TypeScript/React. El proyecto usa un frontend React 18 + TypeScript + Vite corriendo en Docker Compose.
+
+**Acciones disponibles:**
+- `run` — Ejecutar todos los tests E2E
+- `run <page>` — Ejecutar tests de una pagina (home, dashboard, catalog, operations, explorer, embeddings, chat)
+- `screenshots` — Generar capturas de todas las paginas
+- `new <page> <descripcion>` — Crear un test E2E nuevo
+- `status` — Verificar que los containers estan running y healthy
+- `help` — Mostrar esta ayuda
+
+---
+
+## Prerequisitos
+
+Los containers de backend + frontend + bases de datos DEBEN estar corriendo:
+
+```bash
+docker compose up --build -d
+# Frontend: http://localhost:5173
+# Backend: http://localhost:8000
+```
+
+---
+
+## Stack E2E
+
+- **Playwright** for TypeScript (via `npx playwright`)
+- **Test location:** `frontend/webapp/tests/e2e/`
+- **Config:** `frontend/webapp/playwright.config.ts`
+
+---
+
+## Comandos
+
+```bash
+# 1. Levantar servicios (si no estan)
+docker compose up --build -d
+
+# 2. Instalar Playwright (primera vez)
+cd frontend/webapp && npx playwright install --with-deps chromium
+
+# 3. Ejecutar todos los E2E
+cd frontend/webapp && npx playwright test
+
+# 4. Ejecutar tests de una pagina
+cd frontend/webapp && npx playwright test tests/e2e/test_catalog.spec.ts
+
+# 5. Ejecutar con UI mode (debug)
+cd frontend/webapp && npx playwright test --ui
+
+# 6. Generar capturas
+cd frontend/webapp && npx playwright test --update-snapshots
+```
+
+---
+
+## Estructura
+
+```
+frontend/webapp/
+  tests/e2e/
+    home.spec.ts          Home page
+    dashboard.spec.ts     Dashboard: health, DB status, jobs
+    catalog.spec.ts       Catalog: competitions, matches
+    operations.spec.ts    Operations: download, load, process
+    explorer.spec.ts      Explorer: teams, players, events
+    embeddings.spec.ts    Embeddings: coverage, rebuild
+    chat.spec.ts          Chat: RAG semantic search
+  playwright.config.ts    Config: baseURL, timeouts, projects
+```
+
+---
+
+## Selectores preferidos
+
+```typescript
+page.getByRole('button', { name: 'Download' })    // Por rol (mejor)
+page.getByText('Total Matches')                     // Por texto
+page.getByLabel('Source')                            // Por label
+page.getByTestId('sidebar')                          // Por test-id
+```
+
+---
+
+## Plantilla para test nuevo
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('<Page> Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/<route>');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('loads without errors', async ({ page }) => {
+    await expect(page.getByRole('heading')).toBeVisible();
+    await expect(page.locator('text=Error')).toHaveCount(0);
+  });
+
+  test('main content visible', async ({ page }) => {
+    await expect(page.getByText('<expected text>')).toBeVisible();
+  });
+});
+```
+
+---
+
+## Reglas
+
+- **NUNCA** usar `page.waitForTimeout()` — usar `waitForLoadState` o `waitForSelector`
+- **SIEMPRE** usar selectores semánticos (role, text, label) sobre CSS selectors
+- Tests deben ser independientes — no depender del orden de ejecución
+- Cada test debe limpiar su estado si modifica datos
+- Capturas van en `frontend/webapp/tests/e2e/screenshots/`
+
+---
+
+## Comportamiento por accion
+
+### `run`
+1. Verificar containers healthy: `docker compose ps`
+2. Ejecutar: `cd frontend/webapp && npx playwright test`
+
+### `screenshots`
+1. Verificar containers healthy
+2. Ejecutar tests con `--update-snapshots`
+3. Listar capturas generadas
+
+### `new <page> <descripcion>`
+1. Generar test siguiendo plantilla y convenciones del proyecto
+2. Ejecutar para verificar que pasa
+
+### `status`
+1. `docker compose ps` — verificar servicios
+2. `curl http://localhost:8000/api/v1/health/live` — backend health
+3. `curl http://localhost:5173` — frontend health

--- a/.github/skills/git-workflow/SKILL.md
+++ b/.github/skills/git-workflow/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: git-workflow
+description: Git workflow for RAG-Challenge. Branch model with develop (integration) and main (production). Use this when creating branches, committing, pushing, or opening PRs.
+---
+
+# Git Workflow
+
+Git workflow for RAG-Challenge. Uses a **simplified GitFlow** with `develop` (integration) and `main` (production).
+
+## Rules
+
+- **Never push directly to `main` or `develop`** — all changes via feature branch + PR
+- **Conventional Commits** format in English: `type(scope): description`
+- **No AI attribution** in commits or PRs (`Co-Authored-By`, `Generated with`, etc.)
+- **Never force push**
+- **Always update CHANGELOG.md** under `## [Unreleased]` in code PRs
+
+## Branch naming
+
+```
+feature/NNN-description   # New functionality (from develop)
+fix/NNN-description       # Bug fixes (from develop)
+hotfix/NNN-description    # Urgent production fixes (from main)
+chore/description         # Maintenance, tooling, config (from develop)
+refactor/description      # Restructure without behavior change (from develop)
+```
+
+`NNN` = zero-padded sequence number (e.g., `016`, `040`). Get next available from repo.
+
+## Commit types
+
+| Type | When |
+|------|------|
+| `feat(scope)` | New functionality |
+| `fix(scope)` | Bug fix |
+| `docs` | Documentation only |
+| `test(scope)` | Adding or updating tests |
+| `chore(scope)` | Maintenance, CI/CD, dependencies |
+| `refactor(scope)` | Restructure without behavior change |
+| `style` | Formatting only |
+| `perf(scope)` | Performance improvement |
+
+## Workflow for a feature/fix
+
+```bash
+# 1. Start from develop
+git checkout develop && git pull origin develop
+
+# 2. Create branch
+git checkout -b feature/NNN-description
+
+# 3. Work (TDD: tests first, then implementation)
+# ... make changes ...
+
+# 4. Stage and commit
+git add <specific-files>
+git commit -m "feat(scope): description"
+
+# 5. Push
+git push -u origin feature/NNN-description
+
+# 6. Create PR → develop
+gh pr create --base develop --title "feat(scope): description" --body "..."
+
+# 7. After CI green + review → merge (squash if many commits)
+# 8. Delete branch after merge
+```
+
+## OpenSpec integration
+
+For non-trivial changes, use the OpenSpec workflow first:
+
+1. `/opsx:propose <change-name>` — creates proposal, design, specs, tasks
+2. Create branch: `git checkout -b feature/NNN-description`
+3. `/opsx:apply` — implements tasks with TDD
+4. Push, PR, merge
+5. `/opsx:archive` — archives completed change
+
+## PR checklist
+
+- [ ] Branch naming follows `<type>/NNN-description`
+- [ ] Conventional Commits in English
+- [ ] Tests pass: `cd backend && pytest tests/ -v`
+- [ ] Coverage >= 80%
+- [ ] Lint clean: `ruff check backend/app && ruff format --check backend/app`
+- [ ] Type check: `mypy backend/app`
+- [ ] CHANGELOG.md updated under `## [Unreleased]`
+- [ ] `docs/conversation_log.md` updated if AI-assisted session
+
+## Releases
+
+- PR `develop → main` with title `release: vX.Y.Z`
+- Follow Semantic Versioning (MAJOR.MINOR.PATCH)
+- Tag on main after merge: `git tag vX.Y.Z && git push origin vX.Y.Z`
+- Promote `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD` in CHANGELOG


### PR DESCRIPTION
## Summary

- Add 3 new skills for both Claude Code and GitHub Copilot:
  - **git-workflow**: branch model, conventional commits, PR checklist, OpenSpec integration, release process
  - **changelog**: Keep a Changelog format, entry procedure, release rules
  - **e2e-playwright**: Playwright for React frontend, test templates, action commands
- Each skill exists in both `.claude/skills/` (Claude Code) and `.github/skills/` + `.github/prompts/` (Copilot)
- Adapted from garage-tech-radar and snowflake-ia-demos to match RAG-Challenge stack

## Test plan

- [ ] Skills appear in Claude Code (`/git-workflow`, `/changelog`, `/e2e`)
- [ ] Skills appear in GitHub Copilot agent mode
- [ ] No code changes — skills only