### PR TITLE
chore(skills): align skills, AGENTS.md, CLAUDE.md, and CHANGELOG (#47)

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -9,9 +9,21 @@ Update CHANGELOG.md following Keep a Changelog format.
 
 ## When to use this skill
 
-- After implementing a feature or fix (before creating PR)
-- After merging multiple OpenSpec changes
-- Before creating a release tag
+- During `/opsx:apply` — after implementing each task, before the PR
+- After merging an OpenSpec change to develop
+- Before creating a release tag (`develop → main`)
+- Whenever a code PR is ready (mandatory per AGENTS.md)
+
+## Integration with OpenSpec workflow
+
+```
+/opsx:propose  →  /opsx:apply  →  update CHANGELOG  →  commit + PR  →  /opsx:archive
+                                   ^^^^^^^^^^^^^^^^
+                                   you are here
+```
+
+The CHANGELOG entry describes **what changed for users**, not the OpenSpec artifacts.
+Reference the PR number, not the OpenSpec change name.
 
 ## Format
 
@@ -62,10 +74,11 @@ Example:
 
 When the user wants to tag a release:
 
-1. Move `[Unreleased]` content to a new version section `[X.Y.Z] - YYYY-MM-DD`
-2. Create empty `[Unreleased]` section
-3. Update version in `backend/app/main.py`, `README.md`, `PROJECT_STATUS.md`
-4. Versioning:
+1. Verify all OpenSpec changes are archived (`openspec/changes/` should be empty or all archived)
+2. Move `[Unreleased]` content to a new version section `[X.Y.Z] - YYYY-MM-DD`
+3. Create empty `[Unreleased]` section
+4. Update version in `backend/app/main.py`, `README.md`, `PROJECT_STATUS.md`
+5. Versioning:
    - **MAJOR**: breaking API changes
    - **MINOR**: new features, backwards-compatible
    - **PATCH**: bug fixes
@@ -77,4 +90,5 @@ When the user wants to tag a release:
 - ALWAYS use ISO dates (YYYY-MM-DD)
 - NEVER remove existing entries
 - NEVER skip CHANGELOG update in code PRs (docs-only PRs may skip with justification)
+- NEVER include AI attribution in CHANGELOG entries
 - Group entries by type (Added, Changed, Fixed, etc.) — not by PR or date

--- a/.claude/skills/e2e-playwright/SKILL.md
+++ b/.claude/skills/e2e-playwright/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: e2e-playwright
-description: Tests end-to-end con Playwright para el frontend React. Ejecutar tests E2E, crear tests nuevos, generar capturas.
+description: End-to-end tests with Playwright for the React frontend. Run E2E tests, create new tests, generate screenshots.
 argument-hint: <action> [arguments]
 ---
 

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -93,3 +93,4 @@ For non-trivial changes, use the OpenSpec workflow first:
 - Follow Semantic Versioning (MAJOR.MINOR.PATCH)
 - Tag on main after merge: `git tag vX.Y.Z && git push origin vX.Y.Z`
 - Promote `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD` in CHANGELOG
+- Update version in `backend/app/main.py`, `README.md`, `PROJECT_STATUS.md`

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -63,7 +63,7 @@ Archive a completed change in the experimental workflow.
    - If changes needed: "Sync now (recommended)", "Archive without syncing"
    - If already synced: "Archive now", "Sync anyway", "Cancel"
 
-   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+   If user chooses sync, manually apply the delta spec changes to the corresponding main specs at `openspec/specs/<capability>/spec.md` based on the analysis summary. Proceed to archive regardless of choice.
 
 5. **Perform the archive**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,11 +90,18 @@ When a developer asks to implement a feature:
 - **Middleware and module-level config cannot be patched after import.**
   If testing middleware behavior, build a dedicated test app instead of patching.
 
-Available commands (core profile):
+Available commands:
+
+OpenSpec (spec-driven development):
 - `/opsx:propose` — create change with proposal, design, specs, tasks
 - `/opsx:apply` — implement tasks from a change
 - `/opsx:archive` — archive completed change
 - `/opsx:explore` — thinking partner mode (read-only, no code changes)
+
+Project skills:
+- `/git-workflow` — branch model, commits, PRs, releases
+- `/changelog` — update CHANGELOG.md (Keep a Changelog format, integrated with OpenSpec flow)
+- `/e2e-playwright` — Playwright E2E tests for React frontend
 
 ### Parallel development with worktrees
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,30 +9,33 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- **ingestion**: New **summary generation** pipeline stage. `IngestionService.run_generate_summaries_job()` reads rows from `events_details__quarter_minute` / `events_details__15secs_agg` where `summary IS NULL`, builds a prompt per 15-second bucket from `backend/app/services/prompts/event_summary.md`, calls `OpenAIAdapter.create_chat_completion()` and writes the response back. This closes a critical gap: the aggregate stage wrote `summary = NULL` and the embeddings stage filtered `WHERE summary IS NOT NULL`, so embeddings were never created out of the box.
-- **api**: `POST /api/v1/ingestion/summaries/generate` — dedicated endpoint for the new stage.
-- **api**: `POST /api/v1/ingestion/full-pipeline` — orchestrator that runs all 5 stages (`download → load → aggregate → summaries → embeddings`) sequentially in a single background job. Aborts on any stage failure.
-- **scripts**: `backend/scripts/seed_load.py` — dev-path loader that downloads a pre-computed seed dataset from a GitHub Release, verifies sha256 per file, and populates both PostgreSQL and SQL Server **without requiring an OpenAI key**. Idempotent: skips if the seed matches are already present.
-- **scripts**: `backend/scripts/seed_build.py` — maintainer-only script to export the seed dataset to a tarball for publication as a GitHub Release asset. Requires `OPENAI_KEY` and ~$0.30 of OpenAI budget (~5,000 summaries + embeddings for both matches).
-- **seed dataset**: Two canonical finals pre-configured as the seed: Euro 2024 Final (Spain 2-1 England, `match_id=3943043`) and FIFA World Cup 2022 Final (Argentina 3-3 France, `match_id=3869685`). Raw StatsBomb JSON is downloaded on demand and not committed to the repo (CC BY-NC-SA 4.0).
-- **devcontainer**: `.devcontainer/post-create.sh` now calls `scripts.seed_load` on first open so the dashboard is populated automatically.
-- **docs**: `data/seed/README.md` documenting the seed dataset, regeneration process, and licensing.
-- **docs**: `docs/getting-started.md` has a new "First run — seed dataset" section.
-- **tooling**: Root-level `Makefile` with `seed`, `seed-force`, `seed-postgres`, `seed-sqlserver`, `test`, `lint`, `format` targets.
-- **tests**: 60+ new unit tests across `test_summary_generation.py`, `test_full_pipeline_orchestrator.py`, `test_seed_build.py`, `test_seed_load.py`, plus 13 new API tests in `test_ingestion.py`.
+- **ingestion**: New **summary generation** pipeline stage. `IngestionService.run_generate_summaries_job()` reads rows from `events_details__quarter_minute` / `events_details__15secs_agg` where `summary IS NULL`, builds a prompt per 15-second bucket from `backend/app/services/prompts/event_summary.md`, calls `OpenAIAdapter.create_chat_completion()` and writes the response back. This closes a critical gap: the aggregate stage wrote `summary = NULL` and the embeddings stage filtered `WHERE summary IS NOT NULL`, so embeddings were never created out of the box (#45)
+- **api**: `POST /api/v1/ingestion/summaries/generate` — dedicated endpoint for the new stage (#45)
+- **api**: `POST /api/v1/ingestion/full-pipeline` — orchestrator that runs all 5 stages (`download → load → aggregate → summaries → embeddings`) sequentially in a single background job. Aborts on any stage failure (#45)
+- **scripts**: `backend/scripts/seed_load.py` — dev-path loader that downloads a pre-computed seed dataset from a GitHub Release, verifies sha256 per file, and populates both PostgreSQL and SQL Server **without requiring an OpenAI key**. Idempotent: skips if the seed matches are already present (#45)
+- **scripts**: `backend/scripts/seed_build.py` — maintainer-only script to export the seed dataset to a tarball for publication as a GitHub Release asset. Requires `OPENAI_KEY` and ~$0.30 of OpenAI budget (~5,000 summaries + embeddings for both matches) (#45)
+- **seed dataset**: Two canonical finals pre-configured as the seed: Euro 2024 Final (Spain 2-1 England, `match_id=3943043`) and FIFA World Cup 2022 Final (Argentina 3-3 France, `match_id=3869685`). Raw StatsBomb JSON is downloaded on demand and not committed to the repo (CC BY-NC-SA 4.0) (#45)
+- **devcontainer**: `.devcontainer/post-create.sh` now calls `scripts.seed_load` on first open so the dashboard is populated automatically (#45)
+- **docs**: `data/seed/README.md` documenting the seed dataset, regeneration process, and licensing (#45)
+- **docs**: `docs/getting-started.md` has a new "First run — seed dataset" section (#45)
+- **docs**: `docs/PLAN_V5_IMPROVEMENTS.md` — roadmap with 10 areas of work for v5 (#28)
+- **tooling**: Root-level `Makefile` with `seed`, `seed-force`, `seed-postgres`, `seed-sqlserver`, `test`, `lint`, `format` targets (#45)
+- **tooling**: Claude Code skills for git-workflow, changelog, and e2e-playwright (#46)
+- **tests**: 60+ new unit tests across `test_summary_generation.py`, `test_full_pipeline_orchestrator.py`, `test_seed_build.py`, `test_seed_load.py`, plus 13 new API tests in `test_ingestion.py` (#45)
 
 ### Removed
-- **devcontainer**: The synthetic `match_id=900001` placeholder row in `.devcontainer/post-create.sh` is gone. The real seed dataset replaces it.
+- **devcontainer**: The synthetic `match_id=900001` placeholder row in `.devcontainer/post-create.sh` is gone. The real seed dataset replaces it (#45)
 
 ### Changed
-- **infra**: Split `backend/Dockerfile` into two stages — `runtime` (production) and `devcontainer` (dev only). The production image no longer carries `git`, `nodejs`, `gnupg2`, `apt-transport-https`, `openssh-client`, `less`, or `procps`. Those tools are layered on in the `devcontainer` stage, which is selected via `build.target: devcontainer` in `.devcontainer/docker-compose.override.yml` and is never built by plain `docker compose up`.
-- **infra**: Production backend container now runs as non-root `appuser` (UID 1000) by default — previously only the devcontainer enforced this.
+- **infra**: Split `backend/Dockerfile` into two stages — `runtime` (production) and `devcontainer` (dev only). The production image no longer carries `git`, `nodejs`, `gnupg2`, `apt-transport-https`, `openssh-client`, `less`, or `procps`. Those tools are layered on in the `devcontainer` stage, which is selected via `build.target: devcontainer` in `.devcontainer/docker-compose.override.yml` and is never built by plain `docker compose up` (#43)
+- **infra**: Production backend container now runs as non-root `appuser` (UID 1000) by default — previously only the devcontainer enforced this (#43)
+- **docs**: Clean up README, PROJECT_STATUS, and .gitignore for onboarding (#25)
 
 ### Security
-- Remove `git`, `nodejs`, and dev-only apt tooling from the production backend image, reducing attack surface and image size.
+- Remove `git`, `nodejs`, and dev-only apt tooling from the production backend image, reducing attack surface and image size (#43)
 
 ### Fixed
-- Migrate class-based `Config` to `model_config = ConfigDict(...)` in all 7 response DTOs in `backend/app/api/v1/models.py`, eliminating `PydanticDeprecatedSince20` warnings. `pytest tests/ -v` now runs with zero warnings (was 7).
+- Migrate class-based `Config` to `model_config = ConfigDict(...)` in all 7 response DTOs in `backend/app/api/v1/models.py`, eliminating `PydanticDeprecatedSince20` warnings. `pytest tests/ -v` now runs with zero warnings (was 7) (#43)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,16 @@ This project uses [OpenSpec](https://github.com/Fission-AI/OpenSpec) for spec-dr
 
 ## Claude-specific tools
 
-- OpenSpec slash commands: `.claude/commands/opsx/{propose,apply,archive,explore}.md`
-- OpenSpec skills: `.claude/skills/openspec-{propose,apply-change,archive-change,explore}/SKILL.md`
+### OpenSpec (spec-driven development)
+- Slash commands: `/opsx:propose`, `/opsx:apply`, `/opsx:archive`, `/opsx:explore`
+- Skills: `.claude/skills/openspec-{propose,apply-change,archive-change,explore}/SKILL.md`
+
+### Project skills
+- `/git-workflow` — branch model, commits, PRs, releases
+- `/changelog` — update CHANGELOG.md (Keep a Changelog format)
+- `/e2e-playwright` — Playwright E2E tests for React frontend
+
+### Config
 - Settings: `.claude/settings.local.json`
 
 ## Key commands


### PR DESCRIPTION
## Summary

- Rename `/e2e` to `/e2e-playwright` in CLAUDE.md and AGENTS.md to match skill frontmatter name
- Translate e2e-playwright description to English for consistency with other skills
- Add release version files checklist to git-workflow skill (was in changelog but missing here)
- Remove reference to non-existent `openspec-sync-specs` skill in archive — replaced with inline sync instruction
- Add missing project skills section (`/git-workflow`, `/changelog`, `/e2e-playwright`) to AGENTS.md and CLAUDE.md
- Enrich changelog skill with OpenSpec integration flow, timing guidance, and no-AI-attribution rule
- Add missing CHANGELOG entries for #25, #28, #46; add `(#NN)` PR numbers to all Unreleased entries

## Test plan

- [ ] Verify `/changelog`, `/git-workflow`, `/e2e-playwright` skills resolve correctly
- [ ] Verify CHANGELOG [Unreleased] entries match post-v4.0.0 commits
- [ ] Verify no broken references in AGENTS.md or CLAUDE.md