### PR TITLE
fix(sqlserver): achieve data parity — seed loading, vector search, and docs (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - **rag**: Deprecate `text-embedding-ada-002` and `text-embedding-3-large` — only `text-embedding-3-small` is active. Deprecated models removed from capabilities API and UI, enum values retained for backward compatibility (#51)
+- **sqlserver**: Fix seed data loading into SQL Server — pyodbc ntext-to-vector cast issue resolved with `setinputsizes`. Both databases now have identical seed data after `make seed` (#52)
+- **sqlserver**: Fix RAG search on SQL Server — same ntext-to-vector cast fix in `SQLServerEventRepository.search_by_embedding` (#52)
+- **docs**: `docs/sql-server-setup.md` — dedicated SQL Server setup guide with schema differences, Docker config, vector search limitations, and troubleshooting (#52)
 - **infra**: Split `backend/Dockerfile` into two stages — `runtime` (production) and `devcontainer` (dev only). The production image no longer carries `git`, `nodejs`, `gnupg2`, `apt-transport-https`, `openssh-client`, `less`, or `procps`. Those tools are layered on in the `devcontainer` stage, which is selected via `build.target: devcontainer` in `.devcontainer/docker-compose.override.yml` and is never built by plain `docker compose up` (#43)
 - **infra**: Production backend container now runs as non-root `appuser` (UID 1000) by default — previously only the devcontainer enforced this (#43)
 - **docs**: Clean up README, PROJECT_STATUS, and .gitignore for onboarding (#25)

--- a/backend/app/repositories/sqlserver.py
+++ b/backend/app/repositories/sqlserver.py
@@ -598,6 +598,9 @@ class SQLServerEventRepository(EventRepository):
         try:
             with self.get_connection() as conn:
                 cursor = conn.cursor()
+                # pyodbc promotes long strings (>4000 chars) to ntext,
+                # which SQL Server cannot CAST to VECTOR. Force VARCHAR.
+                cursor.setinputsizes([(pyodbc.SQL_INTEGER, 0, 0), (pyodbc.SQL_VARCHAR, 0, 0), (pyodbc.SQL_INTEGER, 0, 0)])
                 cursor.execute(
                     query,
                     (search_request.top_n, embedding_str, search_request.match_id),

--- a/backend/app/repositories/sqlserver.py
+++ b/backend/app/repositories/sqlserver.py
@@ -600,7 +600,13 @@ class SQLServerEventRepository(EventRepository):
                 cursor = conn.cursor()
                 # pyodbc promotes long strings (>4000 chars) to ntext,
                 # which SQL Server cannot CAST to VECTOR. Force VARCHAR.
-                cursor.setinputsizes([(pyodbc.SQL_INTEGER, 0, 0), (pyodbc.SQL_VARCHAR, 0, 0), (pyodbc.SQL_INTEGER, 0, 0)])
+                cursor.setinputsizes(
+                    [
+                        (pyodbc.SQL_INTEGER, 0, 0),
+                        (pyodbc.SQL_VARCHAR, 0, 0),
+                        (pyodbc.SQL_INTEGER, 0, 0),
+                    ]
+                )
                 cursor.execute(
                     query,
                     (search_request.top_n, embedding_str, search_request.match_id),

--- a/backend/app/services/ingestion_service.py
+++ b/backend/app/services/ingestion_service.py
@@ -1073,6 +1073,7 @@ class IngestionService:
                 emb_str = "[" + ",".join(map(str, emb)) + "]"
                 # pyodbc promotes long strings to ntext; force VARCHAR for VECTOR CAST
                 import pyodbc as _pyodbc
+
                 cur.setinputsizes([(_pyodbc.SQL_VARCHAR, 0, 0)])
                 cur.execute(
                     f"UPDATE events_details__15secs_agg SET {col} = CAST(? AS VECTOR(1536)) WHERE id = ?",

--- a/backend/app/services/ingestion_service.py
+++ b/backend/app/services/ingestion_service.py
@@ -1071,6 +1071,9 @@ class IngestionService:
                     continue
                 emb = adapter.create_embedding(text=summary, model=model)
                 emb_str = "[" + ",".join(map(str, emb)) + "]"
+                # pyodbc promotes long strings to ntext; force VARCHAR for VECTOR CAST
+                import pyodbc as _pyodbc
+                cur.setinputsizes([(_pyodbc.SQL_VARCHAR, 0, 0)])
                 cur.execute(
                     f"UPDATE events_details__15secs_agg SET {col} = CAST(? AS VECTOR(1536)) WHERE id = ?",
                     (emb_str, row_id),

--- a/backend/scripts/seed_load.py
+++ b/backend/scripts/seed_load.py
@@ -356,6 +356,11 @@ def _apply_summaries_and_embeddings(
                         (vector_str, db_id),
                     )
                 else:
+                    # pyodbc promotes long strings (>4000 chars) to ntext,
+                    # which SQL Server cannot CAST to VECTOR. Force VARCHAR.
+                    import pyodbc as _pyodbc
+
+                    cur.setinputsizes([(_pyodbc.SQL_VARCHAR, 0, 0)])
                     cur.execute(
                         "UPDATE events_details__15secs_agg "
                         "SET embedding_3_small = CAST(? AS VECTOR(1536)), "

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -116,14 +116,27 @@ Two backends maintain logically equivalent schemas.
 
 ### SQL Server (VECTOR type)
 
-Same logical schema. Key differences:
+Same logical schema with different naming conventions. The code handles both via the Repository Pattern.
 
 | Aspect | PostgreSQL | SQL Server |
 |--------|-----------|------------|
-| Vector type | `vector(N)` (pgvector extension) | `VECTOR(N)` (native, SQL Server 2022+) |
+| Vector type | `vector(N)` (pgvector extension) | `VECTOR(N)` (native, SQL Server 2025) |
 | Search function | Operators (`<=>`, `<#>`, `<->`) | `VECTOR_DISTANCE('cosine', col, @vec)` |
-| Embedding models | ada-002, t3-small, t3-large | ada-002, t3-small only |
+| Vector indexes | HNSW (pgvector) | Not available (Express edition) |
+| Active embedding model | text-embedding-3-small | text-embedding-3-small |
 | L1 Manhattan | Supported | Not supported |
+
+**Schema naming differences:**
+
+| Concept | PostgreSQL | SQL Server |
+|---------|-----------|------------|
+| Aggregation table | `events_details__quarter_minute` | `events_details__15secs_agg` |
+| Time bucket column | `quarter_minute` | `_15secs` |
+| Embedding column | `summary_embedding_t3_small` | `embedding_3_small` |
+| Primary key | Auto-increment `id` | Composite `(match_id, period, minute, _15secs)` |
+| Extra tables | — | `lineups`, `players` (unused) |
+
+See [docs/sql-server-setup.md](sql-server-setup.md) for the full SQL Server guide.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,6 +52,13 @@ make seed-sqlserver                  # sqlserver only
 cd backend && python -m scripts.seed_load --source both --force  # re-seed
 ```
 
+The seed loads into **both PostgreSQL and SQL Server**. You can switch
+between them at any time using the **Source** dropdown in the header.
+
+> **Note:** SQL Server starts slower (~30s vs ~5s for PostgreSQL). If the
+> seed load fails for SQL Server, wait a moment and retry with `make seed-sqlserver`.
+> See [docs/sql-server-setup.md](sql-server-setup.md) for troubleshooting.
+
 After a successful seed load, the dashboard at http://localhost:5173/dashboard
 should show 2 matches in the explorer, and the chat page can answer
 questions about them (**the chat runtime still needs `OPENAI_KEY` set

--- a/docs/sql-server-setup.md
+++ b/docs/sql-server-setup.md
@@ -1,0 +1,136 @@
+# SQL Server Setup Guide
+
+This guide covers how SQL Server 2025 Express works in the RAG-Challenge project alongside PostgreSQL.
+
+## Quick start
+
+SQL Server starts automatically with `docker compose up`. The seed data loads into both databases:
+
+```bash
+docker compose up -d          # starts all 4 services
+make seed                     # loads seed into both PostgreSQL AND SQL Server
+```
+
+Verify SQL Server has data:
+
+```bash
+curl -s "http://localhost:8000/api/v1/matches?source=sqlserver"
+# Should return 2 matches (Euro 2024 Final, WC 2022 Final)
+
+curl -s "http://localhost:8000/api/v1/competitions?source=sqlserver"
+# Should return 2 competitions (UEFA Euro, FIFA World Cup)
+```
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Frontend (React)  ──  Source: [PostgreSQL ▼] / SQL Server   │
+│                            │                                  │
+│  Backend (FastAPI)         │ ?source=sqlserver                │
+│    ├── PostgresRepository ─┘                                  │
+│    └── SQLServerRepository ──► SQL Server 2025 Express        │
+│                                  ├── VECTOR(1536) columns     │
+│                                  ├── VECTOR_DISTANCE()        │
+│                                  └── No HNSW indexes (Express)│
+└──────────────────────────────────────────────────────────────┘
+```
+
+The `source` parameter in the URL controls which database is queried. All API endpoints support both `postgres` and `sqlserver`.
+
+## Docker configuration
+
+**Image:** Custom build from `mcr.microsoft.com/mssql/server:2025-latest`
+
+**Startup time:** ~30 seconds (vs ~5 seconds for PostgreSQL). The `setup.sh` entrypoint waits for SQL Server to be ready before running init scripts.
+
+**Credentials (local dev only):**
+| Variable | Default |
+|----------|---------|
+| `SQLSERVER_HOST` | `sqlserver` (Docker service name) |
+| `SQLSERVER_DB` | `rag_challenge` |
+| `SQLSERVER_USER` | `sa` |
+| `SQLSERVER_PASSWORD` | `SqlServer_Local_Pwd123!` |
+
+## Schema differences from PostgreSQL
+
+The SQL Server schema was designed independently and uses different naming:
+
+| Concept | PostgreSQL | SQL Server |
+|---------|-----------|------------|
+| Aggregation table | `events_details__quarter_minute` | `events_details__15secs_agg` |
+| Time bucket column | `quarter_minute` | `_15secs` |
+| Embedding column | `summary_embedding_t3_small` | `embedding_3_small` |
+| Ada-002 column | `summary_embedding_ada_002` | `embedding_ada_002` |
+| Primary key | Auto-increment `id` | Composite `(match_id, period, minute, _15secs)` |
+| Extra tables | — | `lineups`, `players` (currently unused) |
+
+The code handles both naming conventions transparently via the Repository Pattern — `PostgresEventRepository` and `SQLServerEventRepository` each know their own table/column names.
+
+## Vector search
+
+SQL Server 2025 supports native `VECTOR(1536)` columns and `VECTOR_DISTANCE()` for similarity search:
+
+```sql
+SELECT TOP 5
+    id, match_id, summary,
+    VECTOR_DISTANCE('cosine', embedding_3_small, CAST(@query_vec AS VECTOR(1536))) AS score
+FROM events_details__15secs_agg
+WHERE match_id = @match_id AND embedding_3_small IS NOT NULL
+ORDER BY score ASC
+```
+
+### HNSW indexes — Express limitation
+
+SQL Server 2025 **Express edition** does not support `CREATE VECTOR INDEX`. Vector searches use sequential scans via `VECTOR_DISTANCE()`. This is acceptable for the seed dataset (~700 rows per match) but would be slow for large datasets.
+
+For production workloads or large datasets, use **SQL Server 2025 Developer or Enterprise edition** which supports:
+
+```sql
+-- Only works on Developer/Enterprise edition
+CREATE VECTOR INDEX idx_embedding_hnsw
+ON events_details__15secs_agg (embedding_3_small)
+USING HNSW
+WITH (METRIC = 'cosine', M = 16, EF_CONSTRUCTION = 64);
+```
+
+### Search algorithm support
+
+| Algorithm | PostgreSQL | SQL Server |
+|-----------|-----------|------------|
+| Cosine | `<=>` operator + HNSW index | `VECTOR_DISTANCE('cosine', ...)` — sequential scan |
+| Inner product | `<#>` operator + HNSW index | `VECTOR_DISTANCE('dot', ...)` — sequential scan |
+| L2 Euclidean | `<->` operator | `VECTOR_DISTANCE('euclidean', ...)` — sequential scan |
+| L1 Manhattan | Custom SQL | Not supported |
+
+## Troubleshooting
+
+### SQL Server container won't start
+```bash
+docker compose logs sqlserver    # check for errors
+docker compose restart sqlserver # retry
+```
+Common cause: insufficient memory. SQL Server Express needs ~512 MB minimum.
+
+### Seed load fails with "ntext to vector" error
+This was a known issue (fixed in PR #52). If you see this error, update to the latest `develop` branch.
+
+### Empty data after seed load
+Check that both databases are healthy before seeding:
+```bash
+docker compose ps     # all 4 services should be healthy/running
+make seed-force       # force re-seed both databases
+```
+
+### Switching source in the UI
+Use the **Source** dropdown in the header bar. All pages (Explorer, Chat, Embeddings) will reload with data from the selected source.
+
+## Files reference
+
+| File | Description |
+|------|-------------|
+| `infra/docker/sqlserver/Dockerfile` | Custom SQL Server image build |
+| `infra/docker/sqlserver/initdb/01-schema.sql` | Schema init script |
+| `infra/docker/sqlserver/setup.sh` | Startup entrypoint |
+| `backend/app/repositories/sqlserver.py` | SQL Server repository (all queries) |
+| `backend/app/core/capabilities.py` | Capability matrix per source |

--- a/frontend/webapp/tests/e2e/cross-cutting.spec.ts
+++ b/frontend/webapp/tests/e2e/cross-cutting.spec.ts
@@ -16,8 +16,8 @@ test.describe('Cross-cutting', () => {
     await sourceSelect.selectOption('sqlserver')
     await page.waitForLoadState('networkidle')
 
-    // Page should reload with sqlserver data (may be empty if seed not loaded into sqlserver)
-    await page.waitForTimeout(2000)
+    // SQL Server should also have seed data loaded
+    await expect(page.getByText(/UEFA Euro|FIFA World Cup/i).first()).toBeVisible({ timeout: 10_000 })
     await page.screenshot({ path: `${SCREENSHOTS}/source-sqlserver.png`, fullPage: true })
   })
 

--- a/infra/docker/sqlserver/initdb/01-schema.sql
+++ b/infra/docker/sqlserver/initdb/01-schema.sql
@@ -184,5 +184,10 @@ BEGIN
 END;
 GO
 
+-- NOTE: SQL Server 2025 Express does not support CREATE VECTOR INDEX.
+-- Vector search uses VECTOR_DISTANCE() with sequential scan.
+-- HNSW indexes require SQL Server 2025 Enterprise/Developer edition.
+-- See docs/sql-server-setup.md for details.
+
 PRINT 'RAG Challenge database schema initialized successfully.';
 GO

--- a/openspec/changes/sqlserver-parity/.openspec.yaml
+++ b/openspec/changes/sqlserver-parity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/sqlserver-parity/design.md
+++ b/openspec/changes/sqlserver-parity/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The project uses a dual-database architecture: PostgreSQL (pgvector) and SQL Server 2025 (native VECTOR). Both are in `docker-compose.yml`, both have init scripts, and the API supports `?source=sqlserver` on all endpoints. However, after seed loading, SQL Server has no data — the seed_load script's SQL Server path either fails silently or never runs the aggregation/summary/embedding update steps correctly.
+
+Key schema differences:
+- PostgreSQL aggregation table: `events_details__quarter_minute`, column `quarter_minute`, embedding `summary_embedding_t3_small`
+- SQL Server aggregation table: `events_details__15secs_agg`, column `_15secs`, embedding `embedding_3_small`
+- SQL Server has extra tables: `lineups`, `players` (unused by seed)
+- SQL Server has no HNSW vector indexes
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix seed_load.py so `make seed` populates both databases with identical data
+- Add HNSW indexes to SQL Server schema for vector search performance
+- Create `docs/sql-server-setup.md` as a standalone developer guide
+- Validate with E2E tests that Explorer/Chat work with `source=sqlserver`
+- Document schema naming differences
+
+**Non-Goals:**
+- Renaming SQL Server tables/columns to match PostgreSQL (too risky, breaks existing deployments)
+- Adding `lineups`/`players` tables to PostgreSQL (separate future work)
+- Performance benchmarking (HNSW vs full scan) — document as future work
+- Changing the Repository Pattern or DI layer (code already handles both sources)
+
+## Decisions
+
+### 1. Keep different table/column names, document why
+The schema was designed independently for each database before the project adopted conventions. Renaming `events_details__15secs_agg` to `events_details__quarter_minute` on SQL Server would require:
+- Schema migration on any existing SQL Server databases
+- Updating every SQL query in the SQL Server repository
+- Risk of breaking the `seed_load.py` position-matching logic
+
+**Decision:** Keep names as-is. Document the mapping in `docs/data-model.md` and `docs/sql-server-setup.md`.
+
+### 2. HNSW index syntax for SQL Server 2025
+SQL Server 2025 supports `CREATE VECTOR INDEX ... USING HNSW`. Parameters:
+- `METRIC = 'cosine'` — matches our primary search algorithm
+- `M = 16` — graph connectivity (default, good for ~1K vectors)
+- `EF_CONSTRUCTION = 64` — build-time quality (default)
+
+Only one index needed: on `embedding_3_small` (the only active model).
+
+### 3. Debug seed_load SQL Server path, not rewrite
+The seed_load.py already has SQL Server support. The issue is likely:
+- The `IngestionService._load_matches` / `_load_events` / `_build_aggregations` methods may not work correctly with the SQL Server connection inside Docker
+- Or the `_apply_summaries_and_embeddings` step may fail on the SQL Server column mapping
+
+**Decision:** Debug the existing code path, fix the specific failure, don't rewrite.
+
+## File change list
+
+| File | Status | Description |
+|------|--------|-------------|
+| `infra/docker/sqlserver/initdb/01-schema.sql` | (modified) | Add HNSW vector index on `embedding_3_small` |
+| `backend/scripts/seed_load.py` | (modified) | Fix SQL Server loading path |
+| `docs/sql-server-setup.md` | (new) | Dedicated SQL Server setup guide |
+| `docs/getting-started.md` | (modified) | Add SQL Server notes and troubleshooting |
+| `docs/data-model.md` | (modified) | Document schema differences between PG and SQL Server |
+| `frontend/webapp/tests/e2e/cross-cutting.spec.ts` | (modified) | Verify sqlserver source has data after seed |
+| `CHANGELOG.md` | (modified) | Update Unreleased section |
+
+## Risks / Trade-offs
+
+- **[SQL Server 2025 HNSW syntax may differ]** → Verified against MS documentation. The syntax is `CREATE VECTOR INDEX ... USING HNSW WITH (METRIC = 'cosine', M = 16, EF_CONSTRUCTION = 64)`.
+- **[seed_load fix may reveal deeper IngestionService bugs]** → If the fix is complex, we document it and create a follow-up issue rather than scope-creeping.
+- **[Schema naming confusion persists]** → Mitigated by clear documentation with a mapping table.
+
+## Rollback strategy
+
+- Revert SQL Server schema changes (drop index if created)
+- Revert seed_load.py changes
+- Remove new docs files
+- No database data changes to undo (seed can be re-run)

--- a/openspec/changes/sqlserver-parity/proposal.md
+++ b/openspec/changes/sqlserver-parity/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+SQL Server is supposed to be a first-class alternative to PostgreSQL, but a developer who switches to `source=sqlserver` gets empty pages. The seed data loads into PostgreSQL but fails silently for SQL Server. There are no HNSW vector indexes, schema naming differs from PostgreSQL (different table and column names), and no setup documentation exists. This prevents the project from demonstrating its multi-database RAG architecture — a key didactic feature. Addresses issues #33 and #52.
+
+## What Changes
+
+- **Fix seed loading into SQL Server** — debug and resolve why `seed_load.py --source sqlserver` produces empty tables
+- **Add HNSW vector indexes** to `events_details__15secs_agg` for `embedding_3_small` (SQL Server 2025 native)
+- **Create setup documentation** — `docs/sql-server-setup.md` with Docker setup, schema differences, and troubleshooting
+- **Update existing docs** — `docs/getting-started.md`, `docs/data-model.md` with SQL Server specifics
+- **Add E2E validation** — verify Explorer and Chat work with `source=sqlserver` after seed
+- **Document schema differences** — explain why table/column names differ between PostgreSQL and SQL Server (no rename — too risky for a brownfield project)
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+- `data`: seed loading must work for both postgres and sqlserver; HNSW indexes added to SQL Server schema
+- `infra`: SQL Server init script updated with vector indexes; documentation added
+
+## Impact
+
+- **Infra** (`infra/docker/sqlserver/initdb/01-schema.sql`): add HNSW index creation
+- **Scripts** (`backend/scripts/seed_load.py`): debug and fix SQL Server loading path
+- **Docs** (`docs/sql-server-setup.md`, `docs/getting-started.md`, `docs/data-model.md`): new and updated docs
+- **Tests** (`frontend/webapp/tests/e2e/cross-cutting.spec.ts`): verify sqlserver source with data
+- **Backward compatibility**: fully backward-compatible — adds indexes and docs, no schema column changes
+- **Affected layers**: Infra (schema), Scripts (seed), Docs, E2E Tests
+- **Test impact**: existing 530 backend tests unaffected; E2E cross-cutting test updated

--- a/openspec/changes/sqlserver-parity/specs/data/spec.md
+++ b/openspec/changes/sqlserver-parity/specs/data/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Seed data loads into both databases
+The seed loader (`scripts/seed_load.py`) SHALL load pre-computed data into both PostgreSQL and SQL Server when invoked with `--source both`. After a successful seed load, both databases MUST have identical match counts, aggregation row counts, and embedding coverage.
+
+#### Scenario: Seed loads into SQL Server successfully
+- **GIVEN** Docker stack is running with both databases healthy
+- **WHEN** `python -m scripts.seed_load --source sqlserver` is executed
+- **THEN** SQL Server SHALL contain 2 matches, their events, aggregations, summaries, and embeddings
+
+#### Scenario: API returns data from SQL Server after seed
+- **GIVEN** seed data has been loaded into SQL Server
+- **WHEN** `GET /api/v1/competitions?source=sqlserver` is requested
+- **THEN** the response SHALL contain at least 2 competitions (UEFA Euro, FIFA World Cup)
+
+#### Scenario: RAG search works on SQL Server
+- **GIVEN** seed data with embeddings has been loaded into SQL Server
+- **WHEN** `POST /api/v1/chat/search?source=sqlserver` is sent with a valid query
+- **THEN** the response SHALL contain an answer with search results
+
+### Requirement: SQL Server HNSW vector indexes
+The SQL Server schema SHALL create HNSW vector indexes on the `embedding_3_small` column of `events_details__15secs_agg` for efficient vector similarity search.
+
+#### Scenario: HNSW index exists after schema init
+- **GIVEN** SQL Server container starts with init script
+- **WHEN** schema initialization completes
+- **THEN** an HNSW vector index SHALL exist on `events_details__15secs_agg.embedding_3_small`
+
+#### Scenario: Vector search uses index
+- **GIVEN** HNSW index exists and data is loaded
+- **WHEN** a vector similarity search is executed
+- **THEN** the query SHALL use the HNSW index (sub-linear search time)

--- a/openspec/changes/sqlserver-parity/specs/infra/spec.md
+++ b/openspec/changes/sqlserver-parity/specs/infra/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: SQL Server setup documentation
+The project SHALL include a dedicated `docs/sql-server-setup.md` document that covers Docker setup, schema structure, naming differences from PostgreSQL, seed loading, and troubleshooting.
+
+#### Scenario: Developer follows SQL Server setup guide
+- **GIVEN** a developer reads `docs/sql-server-setup.md`
+- **WHEN** they follow the step-by-step instructions
+- **THEN** they SHALL have SQL Server running in Docker with seed data loaded and RAG search functional
+
+#### Scenario: Schema differences are documented
+- **GIVEN** a developer reads `docs/data-model.md`
+- **WHEN** they look for SQL Server specifics
+- **THEN** they SHALL find a mapping table showing PostgreSQL vs SQL Server table/column names
+
+### Requirement: Getting started covers both databases
+The `docs/getting-started.md` guide SHALL include SQL Server-specific notes alongside PostgreSQL setup, including startup time differences and troubleshooting.
+
+#### Scenario: Getting started mentions SQL Server
+- **GIVEN** a developer reads `docs/getting-started.md`
+- **WHEN** they look for SQL Server information
+- **THEN** they SHALL find notes about SQL Server Docker setup, slower startup, and how to verify data loaded

--- a/openspec/changes/sqlserver-parity/tasks.md
+++ b/openspec/changes/sqlserver-parity/tasks.md
@@ -1,0 +1,32 @@
+## 1. Debug and fix seed loading into SQL Server
+
+- [x] 1.1 Run `docker compose exec backend python -m scripts.seed_load --source sqlserver --force` and capture the error output
+- [x] 1.2 Identify the failure point in the SQL Server loading path (matches, events, aggregations, summaries, or embeddings)
+- [x] 1.3 Fix the seed_load.py SQL Server path so data loads successfully
+- [x] 1.4 Verify: `curl /api/v1/matches?source=sqlserver` returns 2 seed matches
+- [x] 1.5 Verify: `curl /api/v1/competitions?source=sqlserver` returns competitions
+
+## 2. Add HNSW vector indexes to SQL Server schema
+
+- [x] 2.1 Attempted `CREATE VECTOR INDEX` — SQL Server 2025 Express does not support vector indexes. Documented limitation in schema and docs.
+- [x] 2.2 Added comment to `infra/docker/sqlserver/initdb/01-schema.sql` documenting the Express edition limitation
+- [x] 2.3 Vector search works via `VECTOR_DISTANCE()` with sequential scan (acceptable for seed dataset size)
+- [x] 2.4 Fixed `SQLServerEventRepository.search_by_embedding` — same pyodbc ntext-to-vector cast issue as seed_load
+
+## 3. Documentation
+
+- [x] 3.1 Create `docs/sql-server-setup.md` with: Docker setup, schema overview, naming differences from PostgreSQL, seed loading, troubleshooting (slow startup, ODBC driver)
+- [x] 3.2 Update `docs/getting-started.md` with SQL Server-specific notes (startup time, verification commands)
+- [x] 3.3 Update `docs/data-model.md` with a mapping table: PostgreSQL table/column names vs SQL Server equivalents
+
+## 4. E2E validation
+
+- [x] 4.1 Update `frontend/webapp/tests/e2e/cross-cutting.spec.ts` US-23 to verify SQL Server has data (not just empty page)
+- [x] 4.2 Run E2E tests: `cd frontend/webapp && npx playwright test cross-cutting.spec.ts` (2 passed)
+- [x] 4.3 Test RAG search on SQL Server: `POST /api/v1/chat/search?source=sqlserver` returns an answer
+
+## 5. Final validation
+
+- [x] 5.1 Run backend tests: `cd backend && pytest tests/ -v` (530 passed)
+- [x] 5.2 Run full E2E suite: `cd frontend/webapp && npx playwright test` (23 passed, 1 skipped)
+- [x] 5.3 Update CHANGELOG.md under `## [Unreleased]`


### PR DESCRIPTION
## Summary

- Fix pyodbc ntext-to-vector cast issue in `seed_load.py`, `sqlserver.py` repository, and `ingestion_service.py` — long strings (>4000 chars) auto-promoted to ntext, which SQL Server cannot CAST to VECTOR
- After `make seed`, both PostgreSQL AND SQL Server have 2 matches, 717 aggregation rows, 717 summaries, 717 embeddings
- RAG search (`POST /chat/search?source=sqlserver`) returns answers
- Document SQL Server 2025 Express HNSW limitation (vector indexes not available in Express)
- Create `docs/sql-server-setup.md` — dedicated setup guide with schema differences, Docker config, troubleshooting
- Update `docs/getting-started.md` and `docs/data-model.md` with SQL Server specifics
- E2E test US-23 now verifies SQL Server has data (not just empty page)

## Test plan

- [x] Backend: 530 passed, 0 failed
- [x] E2E: 23 passed, 1 skipped, 0 failed
- [x] `make seed` loads into both databases
- [x] `GET /matches?source=sqlserver` returns 2 matches
- [x] `POST /chat/search?source=sqlserver` returns RAG answer
- [ ] Review `docs/sql-server-setup.md` for completeness

Closes #52