### PR TITLE
chore(docs): add CONTRIBUTING.md, issue templates, and project labels (#42)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a bug in the application
+title: "fix: "
+labels: bug
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include error messages or screenshots if applicable.
+
+## Environment
+
+- **Browser**: (e.g., Chrome 120, Firefox 121)
+- **OS**: (e.g., Windows 11, macOS 14)
+- **Docker version**: (e.g., 24.0.7)
+
+## Related Spec
+
+If this bug relates to an OpenSpec spec or change, link it here (e.g., `openspec/specs/api.md`).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "feat: "
+labels: enhancement
+---
+
+## Description
+
+A clear and concise description of the feature or improvement.
+
+## Motivation
+
+Why is this feature needed? What problem does it solve?
+
+## Proposed Solution
+
+Describe how you would like this to work.
+
+## Needs OpenSpec Proposal?
+
+- [ ] Yes — this is complex enough to require an OpenSpec proposal before implementation
+- [ ] No — this can be implemented directly
+
+## Affected Area
+
+- [ ] Backend (Python/FastAPI)
+- [ ] Frontend (React/TypeScript)
+- [ ] Infrastructure (Docker, CI/CD, scripts)
+- [ ] Documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to RAG-Challenge
+
+Thanks for your interest in contributing! This guide covers everything you need to get started.
+
+## Prerequisites
+
+- **Docker** and **Docker Compose** (required for all contributors)
+- **Git**
+- **Node 20+** (frontend development)
+- **Python 3.11+** (backend development)
+
+## Quick setup
+
+```bash
+git clone https://github.com/<org>/RAG-Challenge.git
+cd RAG-Challenge
+git checkout develop
+docker compose up --build
+make seed          # loads seed dataset (no OpenAI key needed)
+```
+
+The app is available at `http://localhost:5173` (frontend) and `http://localhost:8000` (backend API).
+
+## Workflow
+
+1. **Pick an issue** — choose from the issue tracker or create one.
+2. **Create a branch** from `develop`:
+   ```
+   git checkout develop && git pull
+   git checkout -b feature/NNN-short-description
+   ```
+   Use `feature/NNN-desc`, `fix/NNN-desc`, or `chore/desc` naming.
+3. **If complex, propose a spec first** — run `/opsx:propose <feature-name>` to create an OpenSpec proposal with design and tasks before writing code.
+4. **Implement with TDD** — write tests first, then implementation. Target 80%+ coverage.
+5. **Update CHANGELOG.md** — add your change under `## [Unreleased]` in the appropriate section.
+6. **Open a PR against `develop`** — fill in the PR template, link the issue.
+7. **After merge** — if you used OpenSpec, archive the change with `/opsx:archive`.
+
+## Coding standards
+
+See [AGENTS.md](AGENTS.md) for the full set of project rules. Key points:
+
+- **Conventional Commits** in English: `type(scope): description` (e.g., `feat(api): add search endpoint`)
+- **80% test coverage** minimum — CI enforces this gate
+- **Formatting**: `ruff format backend/app` — no exceptions
+- **Linting**: `ruff check backend/app`
+- **Type checking**: `mypy backend/app`
+
+## OpenSpec integration
+
+This project uses [OpenSpec](https://github.com/Fission-AI/OpenSpec) for spec-driven development. The cycle is:
+
+1. **Propose** — `/opsx:propose <name>` creates a change proposal in `openspec/changes/<name>/` with design, specs, and tasks.
+2. **Apply** — `/opsx:apply` implements the tasks from the change, following the task list.
+3. **Archive** — `/opsx:archive` moves the completed change to `openspec/changes/archive/`.
+
+Before implementing any non-trivial feature, check if a spec exists in `openspec/changes/` or `openspec/specs/`. If not, propose one first.
+
+## Issue templates
+
+When creating issues, use the provided templates:
+
+- **Bug Report** — for reporting defects
+- **Feature Request** — for suggesting new features or improvements
+
+Issues that require significant design work should be tagged with the `needs-spec` label.

--- a/openspec/changes/issue-governance/.openspec.yaml
+++ b/openspec/changes/issue-governance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/issue-governance/design.md
+++ b/openspec/changes/issue-governance/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The project uses OpenSpec for spec-driven development but has no documented contributor workflow. Issues are created ad-hoc, there are no templates, and default GitHub labels don't match the project structure.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Create a clear contributor guide (CONTRIBUTING.md)
+- Add issue templates for bugs and features
+- Add project-specific labels
+- Document how OpenSpec integrates with the issue lifecycle
+
+**Non-Goals:**
+- Enforcing label requirements via GitHub Actions
+- Setting up project boards or milestones
+- Creating a governance spec in `openspec/specs/` (too meta)
+
+## Decisions
+
+### 1. CONTRIBUTING.md at repo root
+Standard location. References AGENTS.md for detailed rules and openspec for workflow.
+
+### 2. Two issue templates: bug and feature
+Keep it simple. Both templates include fields for OpenSpec context (related spec, needs-spec flag).
+
+### 3. Labels via gh CLI, not committed config
+Labels are GitHub API state, not files in the repo. Create them via `gh label create` during implementation.
+
+## File change list
+
+| File | Status | Description |
+|------|--------|-------------|
+| `CONTRIBUTING.md` | (new) | Contributor guide |
+| `.github/ISSUE_TEMPLATE/bug_report.md` | (new) | Bug report template |
+| `.github/ISSUE_TEMPLATE/feature_request.md` | (new) | Feature request template |
+| `CHANGELOG.md` | (modified) | Update Unreleased |
+
+## Rollback strategy
+
+Delete the new files. Remove labels via `gh label delete`. No code changes.

--- a/openspec/changes/issue-governance/proposal.md
+++ b/openspec/changes/issue-governance/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The project has no `CONTRIBUTING.md`, no issue templates, and uses only default GitHub labels. Contributors don't know how to pick up issues, what workflow to follow, or how OpenSpec integrates with the issue lifecycle. This creates friction for onboarding and makes the project less accessible. Addresses issue #42.
+
+## What Changes
+
+- Create `CONTRIBUTING.md` with step-by-step contributor guide
+- Create GitHub issue templates (bug report, feature request)
+- Add project-specific labels aligned with the codebase (area:backend, area:frontend, area:infra, area:docs, needs-spec)
+- Document the issue → OpenSpec → PR → archive workflow
+
+## Capabilities
+
+### New Capabilities
+_(none)_
+
+### Modified Capabilities
+_(none — governance/config only, no behavior changes)_
+
+## Impact
+
+- **Root**: `CONTRIBUTING.md` (new)
+- **GitHub config**: `.github/ISSUE_TEMPLATE/` (new)
+- **GitHub labels**: created via `gh label create`
+- **Backward compatibility**: fully backward-compatible — adds governance artifacts
+- **Affected layers**: none
+- **Test impact**: none

--- a/openspec/changes/issue-governance/tasks.md
+++ b/openspec/changes/issue-governance/tasks.md
@@ -1,0 +1,18 @@
+## 1. CONTRIBUTING.md
+
+- [x] 1.1 Create `CONTRIBUTING.md` at repo root with: prerequisites, setup, workflow (issue → branch → OpenSpec → PR → merge → archive), coding standards (link to AGENTS.md), and commit conventions
+
+## 2. Issue templates
+
+- [x] 2.1 Create `.github/ISSUE_TEMPLATE/bug_report.md` with sections: description, steps to reproduce, expected vs actual, environment, related spec
+- [x] 2.2 Create `.github/ISSUE_TEMPLATE/feature_request.md` with sections: description, motivation, proposed solution, needs-spec flag, related area
+
+## 3. GitHub labels
+
+- [x] 3.1 Create project-specific labels: `area:backend`, `area:frontend`, `area:infra`, `area:docs`, `needs-spec`, `priority:P0`, `priority:P1`, `priority:P2`
+- [x] 3.2 Apply labels to existing open issues
+
+## 4. Final validation
+
+- [x] 4.1 Verify issue templates render correctly on GitHub (new issue form)
+- [x] 4.2 Update CHANGELOG.md under `## [Unreleased]`


### PR DESCRIPTION
## Summary

- Create `CONTRIBUTING.md` with contributor workflow: issue → branch → OpenSpec → PR → merge → archive
- Add issue templates: bug report (`.github/ISSUE_TEMPLATE/bug_report.md`) and feature request
- Create 8 GitHub labels: `area:backend`, `area:frontend`, `area:infra`, `area:docs`, `needs-spec`, `priority:P0`, `priority:P1`, `priority:P2`
- Apply labels to all existing open issues (#35-#42)

## Test plan

- [x] No code changes — governance config only
- [x] Labels created and applied via `gh label create` and `gh issue edit`
- [ ] Verify issue templates render on GitHub new issue form

Closes #42