### PR TITLE
fix(frontend): remove duplicate mode toggle from Home page

### DIFF
--- a/frontend/webapp/src/pages/HomePage.tsx
+++ b/frontend/webapp/src/pages/HomePage.tsx
@@ -1,50 +1,22 @@
-import { useState } from 'react'
-
-type ViewMode = 'fan' | 'developer'
+import { useUISettings } from '../state/ui-settings'
 
 export function HomePage() {
-  const [view, setView] = useState<ViewMode>('fan')
+  const { mode } = useUISettings()
 
   return (
     <div className="space-y-4">
-      {/* Header with view toggle */}
+      {/* Header */}
       <header className="rounded-2xl border border-white/10 bg-panel/70 p-6">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div>
-            <h1 className="text-3xl font-bold text-ink">Football Analytics Platform</h1>
-            <p className="mt-2 text-sm text-mute">
-              Análisis profesional de datos de fútbol con tecnología RAG y vectorización semántica
-            </p>
-          </div>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => setView('fan')}
-              className={`rounded-xl px-4 py-2 text-sm font-semibold transition ${
-                view === 'fan'
-                  ? 'bg-accent/20 text-accent shadow-glow'
-                  : 'border border-white/10 bg-canvas/60 text-mute hover:text-ink'
-              }`}
-            >
-              ⚽ Vista Fan
-            </button>
-            <button
-              type="button"
-              onClick={() => setView('developer')}
-              className={`rounded-xl px-4 py-2 text-sm font-semibold transition ${
-                view === 'developer'
-                  ? 'bg-accent/20 text-accent shadow-glow'
-                  : 'border border-white/10 bg-canvas/60 text-mute hover:text-ink'
-              }`}
-            >
-              💻 Vista Developer
-            </button>
-          </div>
+        <div>
+          <h1 className="text-3xl font-bold text-ink">Football Analytics Platform</h1>
+          <p className="mt-2 text-sm text-mute">
+            Análisis profesional de datos de fútbol con tecnología RAG y vectorización semántica
+          </p>
         </div>
       </header>
 
-      {/* Fan View */}
-      {view === 'fan' && (
+      {/* User View */}
+      {mode === 'user' && (
         <div className="space-y-4">
           {/* Hero section */}
           <article className="rounded-2xl border border-white/10 bg-gradient-to-br from-accent/10 to-transparent p-8">
@@ -158,7 +130,7 @@ export function HomePage() {
       )}
 
       {/* Developer View */}
-      {view === 'developer' && (
+      {mode === 'developer' && (
         <div className="space-y-4">
           {/* Architecture overview */}
           <article className="rounded-2xl border border-white/10 bg-panel/70 p-6">

--- a/frontend/webapp/tests/e2e/home.spec.ts
+++ b/frontend/webapp/tests/e2e/home.spec.ts
@@ -2,14 +2,18 @@ import { test, expect } from '@playwright/test'
 
 const SCREENSHOTS = './tests/e2e/screenshots'
 
+async function setMode(page: any, mode: 'user' | 'developer') {
+  const modeSelect = page.locator('select').filter({ hasText: /User|Developer/i }).first()
+  await modeSelect.selectOption(mode)
+  await page.waitForLoadState('networkidle')
+}
+
 test.describe('Home Page', () => {
-  test.beforeEach(async ({ page }) => {
+  test('US-01: user mode shows hero, feature cards, and quick start guide', async ({ page }) => {
     await page.goto('/')
     await page.waitForLoadState('networkidle')
-  })
+    await setMode(page, 'user')
 
-  test('US-01: fan view shows hero, feature cards, and quick start guide', async ({ page }) => {
-    // Fan view is the default
     await expect(page.getByText('Analiza el fútbol como nunca antes')).toBeVisible()
     await expect(page.getByText('Catálogo Completo')).toBeVisible()
     await expect(page.getByText('Explorador Visual')).toBeVisible()
@@ -20,9 +24,12 @@ test.describe('Home Page', () => {
     await page.screenshot({ path: `${SCREENSHOTS}/home-fan.png`, fullPage: true })
   })
 
-  test('US-02: developer view shows architecture, RAG flow, and API endpoints', async ({ page }) => {
-    await page.getByRole('button', { name: /Developer/i }).click()
-    await expect(page.getByText('Arquitectura del Sistema')).toBeVisible()
+  test('US-02: developer mode shows architecture, RAG flow, and API endpoints', async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await setMode(page, 'developer')
+
+    await expect(page.getByText('Arquitectura del Sistema')).toBeVisible({ timeout: 10_000 })
     await expect(page.getByText('Backend Stack')).toBeVisible()
     await expect(page.getByText('Frontend Stack')).toBeVisible()
     await expect(page.getByText('Flujo de Datos RAG')).toBeVisible()


### PR DESCRIPTION
## Summary

- Remove local `fan/developer` toggle from `HomePage.tsx` (was independent `useState`, ignored global Mode dropdown)
- Home page now uses `useUISettings()` — switching Mode in the header controls Home view
- Update E2E test `home.spec.ts` to use global Mode dropdown instead of clicking removed buttons
- 23 E2E tests pass, 0 failed

## Test plan

- [x] E2E: 23 passed, 1 skipped, 0 failed
- [x] Home user mode shows fan content
- [x] Home developer mode shows architecture content
- [x] Single Mode control (header dropdown only)