### PR TITLE
fix(schema): remove deprecated embedding columns and fix tables-info query

### DIFF
--- a/backend/app/repositories/postgres.py
+++ b/backend/app/repositories/postgres.py
@@ -308,10 +308,7 @@ class PostgresMatchRepository(MatchRepository):
                         SELECT table_name, column_name
                         FROM information_schema.columns
                         WHERE table_schema = 'public'
-                          AND (
-                            udt_name = 'vector'
-                            OR column_name LIKE '%embedding%'
-                          )
+                          AND udt_name = 'vector'
                         ORDER BY table_name, column_name
                         """
                     )
@@ -459,10 +456,7 @@ class PostgresEventRepository(EventRepository):
                         SELECT table_name, column_name
                         FROM information_schema.columns
                         WHERE table_schema = 'public'
-                          AND (
-                            udt_name = 'vector'
-                            OR column_name LIKE '%embedding%'
-                          )
+                          AND udt_name = 'vector'
                         ORDER BY table_name, column_name
                         """
                     )

--- a/backend/app/repositories/sqlserver.py
+++ b/backend/app/repositories/sqlserver.py
@@ -309,7 +309,7 @@ class SQLServerMatchRepository(MatchRepository):
                     FROM sys.columns c
                     JOIN sys.tables t ON c.object_id = t.object_id
                     LEFT JOIN sys.types ty ON c.user_type_id = ty.user_type_id
-                    WHERE ty.name = 'vector' OR c.name LIKE '%embedding%'
+                    WHERE ty.name = 'vector'
                     ORDER BY t.name, c.name
                     """
                 )
@@ -464,7 +464,7 @@ class SQLServerEventRepository(EventRepository):
                     FROM sys.columns c
                     JOIN sys.tables t ON c.object_id = t.object_id
                     LEFT JOIN sys.types ty ON c.user_type_id = ty.user_type_id
-                    WHERE ty.name = 'vector' OR c.name LIKE '%embedding%'
+                    WHERE ty.name = 'vector'
                     ORDER BY t.name, c.name
                     """
                 )

--- a/infra/docker/postgres/initdb/02-schema.sql
+++ b/infra/docker/postgres/initdb/02-schema.sql
@@ -98,10 +98,8 @@ CREATE TABLE IF NOT EXISTS events_details__quarter_minute (
     summary TEXT,
     summary_script TEXT,
 
-    -- Embedding columns (populated by application via OpenAI API, not DB-generated)
-    summary_embedding_ada_002       VECTOR(1536),  -- text-embedding-ada-002
-    summary_embedding_t3_small      VECTOR(1536),  -- text-embedding-3-small
-    summary_embedding_t3_large      VECTOR(3072),  -- text-embedding-3-large
+    -- Embedding column (only text-embedding-3-small is active; ada-002 and t3-large deprecated)
+    summary_embedding_t3_small      VECTOR(1536),  -- text-embedding-3-small (active)
 
     -- Embedding lifecycle tracking
     embedding_status                VARCHAR(20) DEFAULT 'pending',  -- pending | done | error
@@ -111,12 +109,7 @@ CREATE TABLE IF NOT EXISTS events_details__quarter_minute (
 
 CREATE INDEX IF NOT EXISTS idx_edqm_match_id ON events_details__quarter_minute(match_id);
 
--- HNSW indexes for vector similarity search
-CREATE INDEX IF NOT EXISTS idx_edqm_ada002_cosine
-    ON events_details__quarter_minute USING hnsw (summary_embedding_ada_002 vector_cosine_ops);
-CREATE INDEX IF NOT EXISTS idx_edqm_ada002_ip
-    ON events_details__quarter_minute USING hnsw (summary_embedding_ada_002 vector_ip_ops);
-
+-- HNSW indexes for vector similarity search (text-embedding-3-small only)
 CREATE INDEX IF NOT EXISTS idx_edqm_t3small_cosine
     ON events_details__quarter_minute USING hnsw (summary_embedding_t3_small vector_cosine_ops);
 CREATE INDEX IF NOT EXISTS idx_edqm_t3small_ip

--- a/infra/docker/sqlserver/initdb/01-schema.sql
+++ b/infra/docker/sqlserver/initdb/01-schema.sql
@@ -54,7 +54,7 @@ BEGIN
         referee_country VARCHAR(255),
 
         json_ TEXT NULL,
-        embeddings VECTOR(1536) NULL
+        -- embeddings column removed — only events_details__15secs_agg has active vector columns
     );
 
     CREATE NONCLUSTERED INDEX nci_competition_name_season_name
@@ -78,7 +78,7 @@ BEGIN
         away_team_id INTEGER NOT NULL,
         away_team_name VARCHAR(255) NOT NULL,
         json_ TEXT NULL,
-        embeddings VECTOR(1536) NULL
+        -- embeddings column removed — only events_details__15secs_agg has active vector columns
     );
 
     CREATE INDEX nci_lineups_match_id ON lineups(match_id);
@@ -123,7 +123,7 @@ BEGIN
         id INT IDENTITY PRIMARY KEY,
         match_id INTEGER,
         json_ NVARCHAR(MAX) NULL,
-        embeddings VECTOR(1536) NULL
+        -- embeddings column removed — only events_details__15secs_agg has active vector columns
     );
 
     CREATE INDEX nci_events_match_id ON events(match_id);
@@ -152,7 +152,7 @@ BEGIN
         play_pattern_id INT NULL,
         play_pattern VARCHAR(255) NULL,
         json_ NVARCHAR(MAX) NULL,
-        embeddings VECTOR(1536) NULL
+        -- embeddings column removed — only events_details__15secs_agg has active vector columns
     );
 
     CREATE INDEX nci_events_details_match_id ON events_details(match_id);
@@ -173,8 +173,7 @@ BEGIN
         count INT,
         json_ NVARCHAR(MAX),
         summary NVARCHAR(MAX),
-        embedding_3_small VECTOR(1536),
-        embedding_ada_002 VECTOR(1536),
+        embedding_3_small VECTOR(1536),  -- text-embedding-3-small (active)
         -- Embedding lifecycle tracking
         embedding_status VARCHAR(20) DEFAULT 'pending',  -- pending | done | error
         embedding_updated_at DATETIME2,


### PR DESCRIPTION
## Summary

- Remove `summary_embedding_ada_002` and `summary_embedding_t3_large` columns from PostgreSQL init schema + their HNSW indexes
- Remove `embedding_ada_002` from SQL Server init schema
- Remove unused `embeddings VECTOR(1536)` columns from `matches`, `events`, `events_details`, `lineups` in SQL Server
- Fix `get_tables_info()` query in both repos: use `udt_name = 'vector'` instead of `LIKE '%embedding%'` to stop reporting tracking columns (status, error, updated_at)

After this change, `/tables-info` only shows actual active vector columns:
- PostgreSQL: `summary_embedding_t3_small` on `events_details__quarter_minute`
- SQL Server: `embedding_3_small` on `events_details__15secs_agg`

**Note:** Init scripts define the schema for new installs. Existing databases keep the old columns until a migration is run — no data loss.

## Test plan

- [x] Backend: 530 passed, 0 failed
- [ ] Verify `/tables-info?source=postgres` shows only t3_small
- [ ] Verify `/tables-info?source=sqlserver` shows only embedding_3_small