### PR TITLE
feat(frontend): add Generate Summaries button to Operations page

### DIFF
--- a/frontend/webapp/src/lib/api/client.ts
+++ b/frontend/webapp/src/lib/api/client.ts
@@ -20,6 +20,7 @@ import type {
   SearchRequestPayload,
   SearchResponse,
   Source,
+  SummariesGenerateRequestPayload,
   SourceStatusResponse,
   StatsBombCompetition,
   StatsBombMatch,
@@ -112,6 +113,12 @@ export const api = {
 
   startAggregate: (payload: AggregateRequestPayload) =>
     request<JobCreateResponse>('/ingestion/aggregate', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+
+  startGenerateSummaries: (payload: SummariesGenerateRequestPayload) =>
+    request<JobCreateResponse>('/ingestion/summaries/generate', {
       method: 'POST',
       body: JSON.stringify(payload),
     }),

--- a/frontend/webapp/src/lib/api/types.ts
+++ b/frontend/webapp/src/lib/api/types.ts
@@ -201,6 +201,12 @@ export interface AggregateRequestPayload {
   match_ids: number[]
 }
 
+export interface SummariesGenerateRequestPayload {
+  source: Source
+  match_ids: number[]
+  language?: string
+}
+
 export interface EmbeddingsRebuildRequestPayload {
   source: Source
   match_ids: number[]

--- a/frontend/webapp/src/pages/OperationsPage.tsx
+++ b/frontend/webapp/src/pages/OperationsPage.tsx
@@ -7,7 +7,7 @@ import { readCatalogSelection } from '../lib/storage/catalogSelection'
 import { useUISettings } from '../state/ui-settings'
 
 const AVAILABLE_DATASETS = ['matches', 'lineups', 'events'] as const
-const TERMINAL_JOB_TYPES = new Set(['load', 'aggregate', 'embeddings_rebuild'])
+const TERMINAL_JOB_TYPES = new Set(['load', 'aggregate', 'summaries_generate', 'embeddings_rebuild'])
 
 function asErrorMessage(error: unknown): string {
   if (error instanceof ApiError) {
@@ -182,6 +182,19 @@ export function OperationsPage() {
   const aggregateMutation = useMutation({
     mutationFn: () =>
       api.startAggregate({
+        source,
+        match_ids: selection.matchIds,
+      }),
+    onSuccess: (response) => {
+      setSelectedJobId(response.job_id)
+      setTerminalJobId(response.job_id)
+      refreshJobs()
+    },
+  })
+
+  const summariesMutation = useMutation({
+    mutationFn: () =>
+      api.startGenerateSummaries({
         source,
         match_ids: selection.matchIds,
       }),
@@ -375,6 +388,14 @@ export function OperationsPage() {
             </button>
             <button
               type="button"
+              onClick={() => summariesMutation.mutate()}
+              disabled={summariesMutation.isPending}
+              className="rounded-xl border border-white/20 bg-white/5 px-4 py-2 text-sm font-semibold text-ink disabled:opacity-60"
+            >
+              Generar summaries
+            </button>
+            <button
+              type="button"
               onClick={() => embeddingsMutation.mutate()}
               disabled={embeddingsMutation.isPending}
               className="rounded-xl border border-white/20 bg-white/5 px-4 py-2 text-sm font-semibold text-ink disabled:opacity-60"
@@ -384,6 +405,7 @@ export function OperationsPage() {
           </div>
           {loadMutation.isError ? <p className="text-sm text-rose-300">{asErrorMessage(loadMutation.error)}</p> : null}
           {aggregateMutation.isError ? <p className="text-sm text-rose-300">{asErrorMessage(aggregateMutation.error)}</p> : null}
+          {summariesMutation.isError ? <p className="text-sm text-rose-300">{asErrorMessage(summariesMutation.error)}</p> : null}
           {embeddingsMutation.isError ? <p className="text-sm text-rose-300">{asErrorMessage(embeddingsMutation.error)}</p> : null}
 
           <div className="rounded-lg border border-white/10 bg-black/80 p-3">

--- a/frontend/webapp/tests/e2e/operations.spec.ts
+++ b/frontend/webapp/tests/e2e/operations.spec.ts
@@ -20,6 +20,10 @@ test.describe('Operations Page', () => {
     await expect(page.getByText(/pipeline|completo|full/i).first()).toBeVisible({ timeout: 10_000 })
   })
 
+  test('US-08b: shows generate summaries button', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /summar|resumen/i })).toBeVisible({ timeout: 10_000 })
+  })
+
   test('US-10: job terminal area is visible', async ({ page }) => {
     // Terminal or log area should exist
     await expect(page.getByText(/job|terminal|log/i).first()).toBeVisible({ timeout: 10_000 })


### PR DESCRIPTION
## Summary

Add the missing 4th pipeline step to Operations UI. The backend endpoint `POST /ingestion/summaries/generate` existed but had no UI button.

Pipeline now complete in UI:
**Download → Load → Aggregate → Summaries → Embeddings**

Changes:
- Add `SummariesGenerateRequestPayload` type
- Add `startGenerateSummaries` API client method  
- Add "Generar summaries" button between Aggregate and Rebuild Embeddings
- Add `summaries_generate` to terminal job types for auto-log display
- E2E test US-08b verifies the button is visible

## Test plan

- [x] E2E operations: 4 passed, 1 skipped, 0 failed
- [ ] Click "Generar summaries" with match selection — job starts and logs appear in terminal