### PR TITLE
fix(ingestion): commit every 25 rows in summaries and embeddings jobs

### DIFF
--- a/backend/app/services/ingestion_service.py
+++ b/backend/app/services/ingestion_service.py
@@ -377,6 +377,8 @@ class IngestionService:
                     )
                     updated += 1
                     if idx % 25 == 0 or idx == len(rows):
+                        # Commit every 25 rows so progress is durable
+                        conn.commit()
                         JobService.log(
                             job_id, f"$ embeddings progress {idx}/{len(rows)}"
                         )
@@ -765,6 +767,8 @@ class IngestionService:
                         errored += 1
                         JobService.log(job_id, f"ERROR row {row_id}: {str(e)[:200]}")
                     if idx % 25 == 0 or idx == len(rows):
+                        # Commit every 25 rows so progress is durable
+                        conn.commit()
                         JobService.log(
                             job_id, f"$ summaries progress {idx}/{len(rows)}"
                         )


### PR DESCRIPTION
## Summary

Both `run_generate_summaries_job` and `run_rebuild_embeddings_job` ran inside a single database transaction. If the job failed at row 1500 of 1986, all 1500 summaries were lost.

Fix: `conn.commit()` every 25 rows (aligned with the existing progress logging interval).

## Impact

- Summaries job: ~5 min of work survives a crash instead of 0
- Embeddings job: same improvement
- No behavior change for successful jobs

## Test plan

- [x] Backend: 530 passed, 0 failed