### PR TITLE
feat: pipeline status endpoint + match selection table in Operations

### DIFF
--- a/backend/app/api/v1/ingestion.py
+++ b/backend/app/api/v1/ingestion.py
@@ -325,6 +325,19 @@ async def start_full_pipeline_job(
 
 
 @router.get(
+    "/ingestion/pipeline-status",
+    status_code=status.HTTP_200_OK,
+    summary="Get per-match pipeline status",
+)
+async def get_pipeline_status(
+    service: IngestionSvc,
+    source: str = Query(default="postgres"),
+) -> list[dict]:
+    src = normalize_source(source)
+    return service.get_pipeline_status(src)
+
+
+@router.get(
     "/ingestion/jobs",
     response_model=JobListResponse,
     status_code=status.HTTP_200_OK,

--- a/backend/app/services/ingestion_service.py
+++ b/backend/app/services/ingestion_service.py
@@ -392,6 +392,49 @@ class IngestionService:
         except Exception as e:
             JobService.fail(job_id, str(e))
 
+    def get_pipeline_status(self, source: str) -> list[dict[str, Any]]:
+        """Return per-match pipeline state: events, aggregations, summaries, embeddings counts."""
+        src = normalize_source(source)
+        with self._get_connection(src) as conn:
+            cur = conn.cursor()
+            if src == "postgres":
+                cur.execute(
+                    """
+                    SELECT m.match_id,
+                           m.home_team_name || ' (' || m.home_score || ') - ' || m.away_team_name || ' (' || m.away_score || ')' AS display_name,
+                           (SELECT COUNT(*) FROM events_details ed WHERE ed.match_id = m.match_id) AS events_count,
+                           (SELECT COUNT(*) FROM events_details__quarter_minute a WHERE a.match_id = m.match_id) AS agg_count,
+                           (SELECT COUNT(*) FROM events_details__quarter_minute a WHERE a.match_id = m.match_id AND a.summary IS NOT NULL) AS summary_count,
+                           (SELECT COUNT(*) FROM events_details__quarter_minute a WHERE a.match_id = m.match_id AND a.summary_embedding_t3_small IS NOT NULL) AS embedding_count
+                    FROM matches m
+                    ORDER BY m.match_id
+                    """
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT m.match_id,
+                           m.home_team_name + ' (' + CAST(m.home_score AS VARCHAR) + ') - ' + m.away_team_name + ' (' + CAST(m.away_score AS VARCHAR) + ')' AS display_name,
+                           (SELECT COUNT(*) FROM events_details ed WHERE ed.match_id = m.match_id) AS events_count,
+                           (SELECT COUNT(*) FROM events_details__15secs_agg a WHERE a.match_id = m.match_id) AS agg_count,
+                           (SELECT COUNT(*) FROM events_details__15secs_agg a WHERE a.match_id = m.match_id AND a.summary IS NOT NULL) AS summary_count,
+                           (SELECT COUNT(*) FROM events_details__15secs_agg a WHERE a.match_id = m.match_id AND a.embedding_3_small IS NOT NULL) AS embedding_count
+                    FROM matches m
+                    ORDER BY m.match_id
+                    """
+                )
+            return [
+                {
+                    "match_id": int(row[0]),
+                    "display_name": row[1] or "",
+                    "events_count": int(row[2] or 0),
+                    "agg_count": int(row[3] or 0),
+                    "summary_count": int(row[4] or 0),
+                    "embedding_count": int(row[5] or 0),
+                }
+                for row in cur.fetchall()
+            ]
+
     def get_embeddings_status(self, source: str) -> dict[str, Any]:
         src = normalize_source(source)
         with self._get_connection(src) as conn:

--- a/frontend/webapp/src/lib/api/client.ts
+++ b/frontend/webapp/src/lib/api/client.ts
@@ -17,6 +17,7 @@ import type {
   MatchSummary,
   PlayerSummary,
   ReadinessResponse,
+  MatchPipelineStatus,
   SearchRequestPayload,
   SearchResponse,
   Source,
@@ -116,6 +117,9 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(payload),
     }),
+
+  getPipelineStatus: (source: Source) =>
+    request<MatchPipelineStatus[]>(withQuery('/ingestion/pipeline-status', { source })),
 
   startGenerateSummaries: (payload: SummariesGenerateRequestPayload) =>
     request<JobCreateResponse>('/ingestion/summaries/generate', {

--- a/frontend/webapp/src/lib/api/types.ts
+++ b/frontend/webapp/src/lib/api/types.ts
@@ -201,6 +201,15 @@ export interface AggregateRequestPayload {
   match_ids: number[]
 }
 
+export interface MatchPipelineStatus {
+  match_id: number
+  display_name: string
+  events_count: number
+  agg_count: number
+  summary_count: number
+  embedding_count: number
+}
+
 export interface SummariesGenerateRequestPayload {
   source: Source
   match_ids: number[]

--- a/frontend/webapp/src/pages/OperationsPage.tsx
+++ b/frontend/webapp/src/pages/OperationsPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { api, ApiError } from '../lib/api/client'
-import type { DownloadCleanupResponse, JobRecord } from '../lib/api/types'
+import type { DownloadCleanupResponse, JobRecord, MatchPipelineStatus } from '../lib/api/types'
 import { readCatalogSelection } from '../lib/storage/catalogSelection'
 import { useUISettings } from '../state/ui-settings'
 
@@ -14,9 +14,7 @@ function asErrorMessage(error: unknown): string {
     const detail = (error.detail as { detail?: string } | null)?.detail
     return detail ? `${error.message}: ${detail}` : error.message
   }
-  if (error instanceof Error) {
-    return error.message
-  }
+  if (error instanceof Error) return error.message
   return 'Unknown error'
 }
 
@@ -29,15 +27,19 @@ export function OperationsPage() {
 
   const [downloadDatasets, setDownloadDatasets] = useState<string[]>(['matches', 'events'])
   const [loadDatasets, setLoadDatasets] = useState<string[]>(['matches', 'events'])
-
-  // Cleanup state
+  const [selectedMatchIds, setSelectedMatchIds] = useState<number[]>([])
   const [cleanupDatasets, setCleanupDatasets] = useState<string[]>(['matches', 'lineups', 'events'])
   const [cleanupResult, setCleanupResult] = useState<DownloadCleanupResponse | null>(null)
-
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null)
   const [terminalJobId, setTerminalJobId] = useState<string | null>(null)
 
-  // Queries
+  // Pipeline status query
+  const pipelineQuery = useQuery({
+    queryKey: ['pipeline-status', source],
+    queryFn: () => api.getPipelineStatus(source),
+    refetchInterval: 5000,
+  })
+
   const jobsQuery = useQuery({
     queryKey: ['jobs-list'],
     queryFn: () => api.listJobs(100),
@@ -61,17 +63,18 @@ export function OperationsPage() {
   const selectedJob = useMemo(() => {
     if (selectedJobQuery.data) return selectedJobQuery.data
     if (!selectedJobId || !jobsQuery.data) return null
-    return jobsQuery.data.items.find((job) => job.id === selectedJobId) ?? null
+    return jobsQuery.data.items.find((j) => j.id === selectedJobId) ?? null
   }, [jobsQuery.data, selectedJobId, selectedJobQuery.data])
 
   const terminalJob = useMemo(() => {
     if (terminalJobQuery.data) return terminalJobQuery.data
     if (!terminalJobId || !jobsQuery.data) return null
-    return jobsQuery.data.items.find((job) => job.id === terminalJobId) ?? null
+    return jobsQuery.data.items.find((j) => j.id === terminalJobId) ?? null
   }, [jobsQuery.data, terminalJobId, terminalJobQuery.data])
 
   const refreshJobs = () => {
     void queryClient.invalidateQueries({ queryKey: ['jobs-list'] })
+    void queryClient.invalidateQueries({ queryKey: ['pipeline-status'] })
   }
 
   const onJobCreated = (response: { job_id: string }) => {
@@ -80,8 +83,19 @@ export function OperationsPage() {
     refreshJobs()
   }
 
-  const toggleDataset = (dataset: string, current: string[], setter: (v: string[]) => void) => {
-    setter(current.includes(dataset) ? current.filter((d) => d !== dataset) : [...current, dataset])
+  const toggleDataset = (d: string, cur: string[], set: (v: string[]) => void) => {
+    set(cur.includes(d) ? cur.filter((x) => x !== d) : [...cur, d])
+  }
+
+  const toggleMatch = (matchId: number) => {
+    setSelectedMatchIds((cur) =>
+      cur.includes(matchId) ? cur.filter((id) => id !== matchId) : [...cur, matchId],
+    )
+  }
+
+  const toggleAllMatches = () => {
+    const all = (pipelineQuery.data ?? []).map((m) => m.match_id)
+    setSelectedMatchIds((cur) => (cur.length === all.length ? [] : all))
   }
 
   const setActiveJob = (job: JobRecord) => {
@@ -110,19 +124,19 @@ export function OperationsPage() {
 
   const aggregateMutation = useMutation({
     mutationFn: () =>
-      api.startAggregate({ source, match_ids: selection.matchIds }),
+      api.startAggregate({ source, match_ids: selectedMatchIds }),
     onSuccess: onJobCreated,
   })
 
   const summariesMutation = useMutation({
     mutationFn: () =>
-      api.startGenerateSummaries({ source, match_ids: selection.matchIds }),
+      api.startGenerateSummaries({ source, match_ids: selectedMatchIds }),
     onSuccess: onJobCreated,
   })
 
   const embeddingsMutation = useMutation({
     mutationFn: () =>
-      api.startRebuildEmbeddings({ source, match_ids: selection.matchIds }),
+      api.startRebuildEmbeddings({ source, match_ids: selectedMatchIds }),
     onSuccess: onJobCreated,
   })
 
@@ -145,99 +159,101 @@ export function OperationsPage() {
 
   return (
     <section className="grid gap-4 xl:grid-cols-[1.1fr_1fr]">
-      {/* Left column: Pipeline */}
       <div className="space-y-4">
-        {/* Match selection header */}
+        {/* Header */}
         <article className="rounded-2xl border border-white/10 bg-panel/70 p-5">
-          <div className="flex items-center justify-between">
-            <h2 className="text-2xl font-semibold text-ink">Pipeline de Ingesta</h2>
-            <button
-              type="button"
-              onClick={() => {
-                const refreshed = readCatalogSelection()
-                setSelection(refreshed)
-              }}
-              className="rounded-lg border border-white/20 bg-white/5 px-3 py-1 text-xs text-ink"
-            >
-              Recargar selección
-            </button>
-          </div>
-          <div className="mt-3 grid gap-2 text-sm md:grid-cols-3">
-            <div className="rounded-lg border border-white/10 bg-canvas/60 px-3 py-2">
-              <p className="text-xs text-mute">Source</p>
-              <p className="font-medium capitalize text-ink">{source}</p>
-            </div>
-            <div className="rounded-lg border border-white/10 bg-canvas/60 px-3 py-2">
-              <p className="text-xs text-mute">Competition / Season</p>
-              <p className="font-medium text-ink">{selection.competitionId ?? '-'} / {selection.seasonId ?? '-'}</p>
-            </div>
-            <div className="rounded-lg border border-white/10 bg-canvas/60 px-3 py-2">
-              <p className="text-xs text-mute">Matches</p>
-              <p className="font-medium text-ink">{selection.matchIds.length > 0 ? `${selection.matchIds.length} selected` : 'none'}</p>
-            </div>
-          </div>
+          <h2 className="text-2xl font-semibold text-ink">Pipeline de Ingesta</h2>
+          <p className="mt-1 text-xs text-mute">
+            Source: <span className="font-semibold capitalize text-ink">{source}</span>
+          </p>
         </article>
 
-        {/* Step 1: Download */}
-        <PipelineStep
-          step={1}
-          title="Download"
-          description="Download match data from StatsBomb Open Data to local storage."
-          actionLabel="Download"
-          onAction={() => downloadMutation.mutate()}
-          isPending={downloadMutation.isPending}
-          error={downloadMutation.isError ? asErrorMessage(downloadMutation.error) : null}
-          disabled={downloadDatasets.length === 0}
-        >
+        {/* Step 1: Download (uses catalog selection) */}
+        <PipelineStep step={1} title="Download" description="Download match data from StatsBomb to local storage.">
+          <div className="mb-2 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setSelection(readCatalogSelection())}
+              className="rounded-lg border border-white/10 px-2 py-1 text-xs text-mute hover:text-ink"
+            >
+              Reload catalog selection
+            </button>
+            <span className="text-xs text-mute">
+              {selection.matchIds.length > 0 ? `${selection.matchIds.length} matches from catalog` : 'No matches selected in catalog'}
+            </span>
+          </div>
           <DatasetCheckboxes datasets={downloadDatasets} toggle={(d) => toggleDataset(d, downloadDatasets, setDownloadDatasets)} prefix="dl" />
+          <ActionButton label="Download" onClick={() => downloadMutation.mutate()} isPending={downloadMutation.isPending} disabled={downloadDatasets.length === 0 || selection.matchIds.length === 0} />
+          {downloadMutation.isError ? <p className="mt-1 text-sm text-rose-300">{asErrorMessage(downloadMutation.error)}</p> : null}
         </PipelineStep>
 
-        {/* Step 2: Load */}
-        <PipelineStep
-          step={2}
-          title="Load"
-          description={`Load downloaded JSON files into ${source} database.`}
-          actionLabel="Load"
-          onAction={() => loadMutation.mutate()}
-          isPending={loadMutation.isPending}
-          error={loadMutation.isError ? asErrorMessage(loadMutation.error) : null}
-          disabled={loadDatasets.length === 0}
-        >
+        {/* Step 2: Load (uses catalog selection) */}
+        <PipelineStep step={2} title="Load" description={`Load downloaded JSON files into ${source} database.`}>
           <DatasetCheckboxes datasets={loadDatasets} toggle={(d) => toggleDataset(d, loadDatasets, setLoadDatasets)} prefix="ld" />
+          <ActionButton label="Load" onClick={() => loadMutation.mutate()} isPending={loadMutation.isPending} disabled={loadDatasets.length === 0 || selection.matchIds.length === 0} />
+          {loadMutation.isError ? <p className="mt-1 text-sm text-rose-300">{asErrorMessage(loadMutation.error)}</p> : null}
         </PipelineStep>
+
+        {/* Match status table (for steps 3-5) */}
+        <article className="rounded-2xl border border-white/10 bg-panel/70 p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-ink">Matches in {source} — select for steps 3-5</h3>
+            <span className="text-xs text-mute">{selectedMatchIds.length} selected</span>
+          </div>
+          {pipelineQuery.isLoading ? <p className="text-xs text-mute">Loading...</p> : null}
+          {pipelineQuery.data && pipelineQuery.data.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-white/10 text-xs">
+                <thead>
+                  <tr className="text-left text-mute">
+                    <th className="px-2 py-1">
+                      <input type="checkbox" checked={selectedMatchIds.length === pipelineQuery.data.length} onChange={toggleAllMatches} />
+                    </th>
+                    <th className="px-2 py-1">Match</th>
+                    <th className="px-2 py-1 text-right">Events</th>
+                    <th className="px-2 py-1 text-right">Agg</th>
+                    <th className="px-2 py-1 text-right">Summ</th>
+                    <th className="px-2 py-1 text-right">Emb</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/5">
+                  {pipelineQuery.data.map((m) => (
+                    <tr key={m.match_id} className={selectedMatchIds.includes(m.match_id) ? 'bg-accent/10' : ''}>
+                      <td className="px-2 py-1">
+                        <input type="checkbox" checked={selectedMatchIds.includes(m.match_id)} onChange={() => toggleMatch(m.match_id)} />
+                      </td>
+                      <td className="px-2 py-1 text-ink">{m.display_name}</td>
+                      <td className="px-2 py-1 text-right text-mute">{m.events_count}</td>
+                      <td className="px-2 py-1 text-right">{m.agg_count > 0 ? <span className="text-emerald-400">{m.agg_count}</span> : <span className="text-mute">0</span>}</td>
+                      <td className="px-2 py-1 text-right">{m.summary_count > 0 ? <span className="text-emerald-400">{m.summary_count}</span> : <span className="text-mute">0</span>}</td>
+                      <td className="px-2 py-1 text-right">{m.embedding_count > 0 ? <span className="text-emerald-400">{m.embedding_count}</span> : <span className="text-mute">0</span>}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : pipelineQuery.data?.length === 0 ? (
+            <p className="text-xs text-mute">No matches loaded in {source}. Run Download + Load first.</p>
+          ) : null}
+        </article>
 
         {/* Step 3: Aggregate */}
-        <PipelineStep
-          step={3}
-          title="Aggregate"
-          description="Build 15-second bucket aggregations from raw events."
-          actionLabel="Aggregate"
-          onAction={() => aggregateMutation.mutate()}
-          isPending={aggregateMutation.isPending}
-          error={aggregateMutation.isError ? asErrorMessage(aggregateMutation.error) : null}
-        />
+        <PipelineStep step={3} title="Aggregate" description="Build 15-second bucket aggregations from raw events.">
+          <ActionButton label="Aggregate" onClick={() => aggregateMutation.mutate()} isPending={aggregateMutation.isPending} disabled={selectedMatchIds.length === 0} />
+          {aggregateMutation.isError ? <p className="mt-1 text-sm text-rose-300">{asErrorMessage(aggregateMutation.error)}</p> : null}
+        </PipelineStep>
 
         {/* Step 4: Summaries */}
-        <PipelineStep
-          step={4}
-          title="Summaries"
-          description="Generate narrative summaries for each 15-second bucket using the LLM. Requires OpenAI key."
-          actionLabel="Generate summaries"
-          onAction={() => summariesMutation.mutate()}
-          isPending={summariesMutation.isPending}
-          error={summariesMutation.isError ? asErrorMessage(summariesMutation.error) : null}
-        />
+        <PipelineStep step={4} title="Summaries" description="Generate narrative summaries per 15-second bucket using LLM. Requires OpenAI key.">
+          <ActionButton label="Generate summaries" onClick={() => summariesMutation.mutate()} isPending={summariesMutation.isPending} disabled={selectedMatchIds.length === 0} />
+          {summariesMutation.isError ? <p className="mt-1 text-sm text-rose-300">{asErrorMessage(summariesMutation.error)}</p> : null}
+        </PipelineStep>
 
         {/* Step 5: Embeddings */}
-        <PipelineStep
-          step={5}
-          title="Embeddings"
-          description="Create vector embeddings (text-embedding-3-small, 1536 dims) for each summary. Requires OpenAI key."
-          actionLabel="Generate embeddings"
-          onAction={() => embeddingsMutation.mutate()}
-          isPending={embeddingsMutation.isPending}
-          error={embeddingsMutation.isError ? asErrorMessage(embeddingsMutation.error) : null}
-        />
+        <PipelineStep step={5} title="Embeddings" description="Create vector embeddings (text-embedding-3-small, 1536 dims) for each summary. Requires OpenAI key.">
+          <ActionButton label="Generate embeddings" onClick={() => embeddingsMutation.mutate()} isPending={embeddingsMutation.isPending} disabled={selectedMatchIds.length === 0} />
+          {embeddingsMutation.isError ? <p className="mt-1 text-sm text-rose-300">{asErrorMessage(embeddingsMutation.error)}</p> : null}
+        </PipelineStep>
 
         {/* Terminal */}
         <div className="rounded-2xl border border-white/10 bg-panel/70 p-4">
@@ -253,51 +269,27 @@ export function OperationsPage() {
 
         {/* Cleanup (collapsible) */}
         <details className="rounded-2xl border border-white/10 bg-panel/70 p-4">
-          <summary className="cursor-pointer text-sm font-semibold text-mute hover:text-ink">
-            Cleanup downloaded files
-          </summary>
+          <summary className="cursor-pointer text-sm font-semibold text-mute hover:text-ink">Cleanup downloaded files</summary>
           <div className="mt-3 space-y-2">
             <DatasetCheckboxes datasets={cleanupDatasets} toggle={(d) => toggleDataset(d, cleanupDatasets, setCleanupDatasets)} prefix="cl" />
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => cleanupAllMutation.mutate()}
-                disabled={cleanupAllMutation.isPending || cleanupDatasets.length === 0}
-                className="rounded-xl border border-rose-400/40 bg-rose-500/10 px-3 py-2 text-xs font-semibold text-rose-300 disabled:opacity-60"
-              >
-                Delete all downloaded files
-              </button>
-            </div>
-            {cleanupAllMutation.isError ? <p className="text-sm text-rose-300">{asErrorMessage(cleanupAllMutation.error)}</p> : null}
-            {cleanupResult ? (
-              <p className="text-xs text-mute">Deleted: {cleanupResult.deleted_count} items</p>
-            ) : null}
+            <button type="button" onClick={() => cleanupAllMutation.mutate()} disabled={cleanupAllMutation.isPending} className="rounded-xl border border-rose-400/40 bg-rose-500/10 px-3 py-2 text-xs font-semibold text-rose-300 disabled:opacity-60">
+              Delete all downloaded files
+            </button>
+            {cleanupResult ? <p className="text-xs text-mute">Deleted: {cleanupResult.deleted_count} items</p> : null}
           </div>
         </details>
       </div>
 
-      {/* Right column: Jobs */}
+      {/* Right: Jobs */}
       <article className="space-y-4 rounded-2xl border border-white/10 bg-panel/70 p-5">
         <div className="flex items-center justify-between">
           <h3 className="text-lg font-semibold text-ink">Jobs</h3>
           <div className="flex gap-2">
-            <button type="button" onClick={refreshJobs} className="rounded-lg border border-white/20 bg-white/5 px-3 py-1 text-xs text-ink">
-              Refresh
-            </button>
-            <button
-              type="button"
-              onClick={() => clearJobsMutation.mutate()}
-              disabled={clearJobsMutation.isPending}
-              className="rounded-lg border border-rose-400/40 bg-rose-500/10 px-3 py-1 text-xs text-rose-300 disabled:opacity-60"
-            >
-              Clear
-            </button>
+            <button type="button" onClick={refreshJobs} className="rounded-lg border border-white/20 bg-white/5 px-3 py-1 text-xs text-ink">Refresh</button>
+            <button type="button" onClick={() => clearJobsMutation.mutate()} disabled={clearJobsMutation.isPending} className="rounded-lg border border-rose-400/40 bg-rose-500/10 px-3 py-1 text-xs text-rose-300 disabled:opacity-60">Clear</button>
           </div>
         </div>
-
         {jobsQuery.isLoading ? <p className="text-mute">Loading jobs...</p> : null}
-        {jobsQuery.isError ? <p className="text-rose-300">Failed to load jobs.</p> : null}
-
         <div className="max-h-[360px] overflow-auto rounded-xl border border-white/10">
           <table className="min-w-full divide-y divide-white/10 text-sm">
             <thead className="bg-canvas/70 text-left text-xs uppercase tracking-[0.16em] text-mute">
@@ -309,11 +301,7 @@ export function OperationsPage() {
             </thead>
             <tbody className="divide-y divide-white/5">
               {(jobsQuery.data?.items ?? []).map((job) => (
-                <tr
-                  key={job.id}
-                  onClick={() => setActiveJob(job)}
-                  className={`cursor-pointer transition hover:bg-white/5 ${selectedJobId === job.id ? 'bg-accent/10' : ''}`}
-                >
+                <tr key={job.id} onClick={() => setActiveJob(job)} className={`cursor-pointer transition hover:bg-white/5 ${selectedJobId === job.id ? 'bg-accent/10' : ''}`}>
                   <td className="px-3 py-2 text-ink">{job.type}</td>
                   <td className="px-3 py-2 text-mute">{job.status}</td>
                   <td className="px-3 py-2 text-mute">{job.total > 0 ? `${job.progress}/${job.total}` : String(job.progress)}</td>
@@ -322,29 +310,14 @@ export function OperationsPage() {
             </tbody>
           </table>
         </div>
-
         {selectedJob ? (
           <div className="rounded-xl border border-white/10 bg-canvas/60 p-4 text-sm">
             <p className="text-mute">Job ID</p>
             <p className="break-all text-ink">{selectedJob.id}</p>
-            <p className="mt-2 text-mute">Status</p>
-            <p className="text-ink">{selectedJob.status}</p>
             <p className="mt-2 text-mute">Message</p>
             <p className="text-ink">{selectedJob.message}</p>
-            {selectedJob.error ? (
-              <>
-                <p className="mt-2 text-mute">Error</p>
-                <p className="text-rose-300">{selectedJob.error}</p>
-              </>
-            ) : null}
-            {selectedJob.result ? (
-              <>
-                <p className="mt-2 text-mute">Result</p>
-                <pre className="mt-1 overflow-auto rounded bg-black/30 p-2 text-xs text-slate-100">
-                  {JSON.stringify(selectedJob.result, null, 2)}
-                </pre>
-              </>
-            ) : null}
+            {selectedJob.error ? <><p className="mt-2 text-mute">Error</p><p className="text-rose-300">{selectedJob.error}</p></> : null}
+            {selectedJob.result ? <><p className="mt-2 text-mute">Result</p><pre className="mt-1 overflow-auto rounded bg-black/30 p-2 text-xs text-slate-100">{JSON.stringify(selectedJob.result, null, 2)}</pre></> : null}
           </div>
         ) : null}
       </article>
@@ -352,77 +325,36 @@ export function OperationsPage() {
   )
 }
 
-// ---------------------------------------------------------------------------
-// Pipeline step card component
-// ---------------------------------------------------------------------------
-
-function PipelineStep({
-  step,
-  title,
-  description,
-  actionLabel,
-  onAction,
-  isPending,
-  error,
-  disabled,
-  children,
-}: {
-  step: number
-  title: string
-  description: string
-  actionLabel: string
-  onAction: () => void
-  isPending: boolean
-  error: string | null
-  disabled?: boolean
-  children?: React.ReactNode
-}) {
+function PipelineStep({ step, title, description, children }: { step: number; title: string; description: string; children: React.ReactNode }) {
   return (
     <article className="rounded-2xl border border-white/10 bg-panel/70 p-4">
       <div className="flex items-start gap-3">
-        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent/15 text-sm font-bold text-accent">
-          {step}
-        </span>
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent/15 text-sm font-bold text-accent">{step}</span>
         <div className="flex-1">
           <h3 className="text-sm font-semibold text-ink">{title}</h3>
           <p className="mt-1 text-xs text-mute">{description}</p>
-          {children ? <div className="mt-2">{children}</div> : null}
-          <div className="mt-3 flex items-center gap-3">
-            <button
-              type="button"
-              onClick={onAction}
-              disabled={isPending || disabled}
-              className="rounded-xl border border-accent/50 bg-accent/15 px-4 py-2 text-sm font-semibold text-accent disabled:opacity-60"
-            >
-              {isPending ? 'Running...' : actionLabel}
-            </button>
-          </div>
-          {error ? <p className="mt-2 text-sm text-rose-300">{error}</p> : null}
+          <div className="mt-2">{children}</div>
         </div>
       </div>
     </article>
   )
 }
 
-// ---------------------------------------------------------------------------
-// Dataset checkboxes component
-// ---------------------------------------------------------------------------
+function ActionButton({ label, onClick, isPending, disabled }: { label: string; onClick: () => void; isPending: boolean; disabled?: boolean }) {
+  return (
+    <button type="button" onClick={onClick} disabled={isPending || disabled} className="mt-2 rounded-xl border border-accent/50 bg-accent/15 px-4 py-2 text-sm font-semibold text-accent disabled:opacity-60">
+      {isPending ? 'Running...' : label}
+    </button>
+  )
+}
 
-function DatasetCheckboxes({
-  datasets,
-  toggle,
-  prefix,
-}: {
-  datasets: string[]
-  toggle: (d: string) => void
-  prefix: string
-}) {
+function DatasetCheckboxes({ datasets, toggle, prefix }: { datasets: string[]; toggle: (d: string) => void; prefix: string }) {
   return (
     <div className="flex flex-wrap gap-2">
-      {AVAILABLE_DATASETS.map((dataset) => (
-        <label key={`${prefix}-${dataset}`} className="flex items-center gap-2 rounded-lg border border-white/10 px-2 py-1 text-xs">
-          <input type="checkbox" checked={datasets.includes(dataset)} onChange={() => toggle(dataset)} />
-          {dataset}
+      {AVAILABLE_DATASETS.map((d) => (
+        <label key={`${prefix}-${d}`} className="flex items-center gap-2 rounded-lg border border-white/10 px-2 py-1 text-xs">
+          <input type="checkbox" checked={datasets.includes(d)} onChange={() => toggle(d)} />
+          {d}
         </label>
       ))}
     </div>

--- a/openspec/changes/pipeline-status-endpoint/.openspec.yaml
+++ b/openspec/changes/pipeline-status-endpoint/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/pipeline-status-endpoint/design.md
+++ b/openspec/changes/pipeline-status-endpoint/design.md
@@ -1,0 +1,32 @@
+## Context
+
+Operations page needs per-match pipeline visibility. Currently the user sees "6 selected" but no state per match.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Backend: one query per source returning per-match counts (events, aggregations, summaries, embeddings)
+- Frontend: table showing match status with checkboxes, each step uses selected matches
+
+**Non-Goals:**
+- Listing downloaded files from disk (would need filesystem access from API — deferred)
+- Per-step progress bars
+
+## Decisions
+
+### 1. Single query per source
+One SQL query joins matches with aggregation counts. Returns all matches loaded in the DB for that source.
+
+### 2. Checkboxes in the match table replace catalog selection for steps 2-5
+Steps 2-5 operate on DB data, not catalog selection. The match table shows what's in the DB and lets the user pick.
+Step 1 (Download) still uses catalog selection since data isn't in the DB yet.
+
+## File change list
+
+| File | Status |
+|------|--------|
+| `backend/app/api/v1/ingestion.py` | (modified) — new endpoint |
+| `backend/app/services/ingestion_service.py` | (modified) — new method |
+| `frontend/webapp/src/lib/api/client.ts` | (modified) — new API call |
+| `frontend/webapp/src/lib/api/types.ts` | (modified) — new type |
+| `frontend/webapp/src/pages/OperationsPage.tsx` | (modified) — match status table |

--- a/openspec/changes/pipeline-status-endpoint/proposal.md
+++ b/openspec/changes/pipeline-status-endpoint/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The Operations page shows match IDs but not their pipeline state. The user can't see which matches have been downloaded, loaded, aggregated, summarized, or embedded. They run steps blindly. Need a per-match pipeline status endpoint and a UI table with checkboxes to select which matches to process at each step.
+
+## What Changes
+
+- New backend endpoint `GET /ingestion/pipeline-status?source=X` returning per-match pipeline state
+- New frontend match status table in Operations with checkboxes for per-step selection
+- Each step's action button uses the selected matches from the table, not from catalog selection
+
+## Capabilities
+
+### New Capabilities
+_(none)_
+
+### Modified Capabilities
+- `api`: new ingestion endpoint for pipeline status per match
+
+## Impact
+
+- **Backend**: new endpoint in `app/api/v1/ingestion.py`, new service method, new repository queries
+- **Frontend**: Operations page gets a match status table with checkboxes
+- **Affected layers**: API, Service, Repository, Frontend
+- **Test impact**: new backend tests for endpoint, updated E2E tests

--- a/openspec/changes/pipeline-status-endpoint/specs/api/spec.md
+++ b/openspec/changes/pipeline-status-endpoint/specs/api/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: Pipeline status per match
+The system SHALL expose `GET /api/v1/ingestion/pipeline-status?source=X` returning per-match pipeline state.
+
+#### Scenario: Returns status for all matches in source
+- **GIVEN** matches are loaded in the database
+- **WHEN** `GET /api/v1/ingestion/pipeline-status?source=postgres` is called
+- **THEN** response SHALL contain an array of objects with: match_id, display_name, events_count, agg_count, summary_count, embedding_count

--- a/openspec/changes/pipeline-status-endpoint/tasks.md
+++ b/openspec/changes/pipeline-status-endpoint/tasks.md
@@ -1,0 +1,17 @@
+## 1. Backend endpoint
+
+- [ ] 1.1 Add `get_pipeline_status` method to IngestionService that queries per-match counts
+- [ ] 1.2 Add `GET /ingestion/pipeline-status` endpoint to `ingestion.py`
+- [ ] 1.3 Test endpoint with curl
+
+## 2. Frontend
+
+- [ ] 2.1 Add API type and client method for pipeline-status
+- [ ] 2.2 Add match status table to Operations page with checkboxes
+- [ ] 2.3 Steps 2-5 use selected matches from the table instead of catalog selection
+
+## 3. Validation
+
+- [ ] 3.1 Run backend tests
+- [ ] 3.2 Run E2E tests
+- [ ] 3.3 Push and PR


### PR DESCRIPTION
## Summary

- **New endpoint** `GET /ingestion/pipeline-status?source=X` — returns per-match counts: events, aggregations, summaries, embeddings
- **Match status table** in Operations with checkboxes and color indicators (green = has data, grey = empty)
- **Per-step selection**: steps 3-5 (Aggregate, Summaries, Embeddings) use matches selected from the table, not from catalog
- Steps 1-2 (Download, Load) still use catalog selection (data not yet in DB)
- Table auto-refreshes every 5 seconds

## Test plan

- [x] Backend: 530 passed, 0 failed
- [x] E2E operations: 4 passed, 1 skipped
- [ ] Visual: select 2 matches, run Aggregate — only those 2 get processed